### PR TITLE
Get rid of Gradle cache in build pipelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           java-version: "${{env.java_version}}"
           distribution: corretto
-          cache: gradle # caches dependencies (https://github.com/actions/setup-java#caching-packages-dependencies)
 
       - name: Build project (Stagenet)
         run: ./gradlew app:assembleStagenetDebug --stacktrace

--- a/.github/workflows/firebase_internal_testing.yml
+++ b/.github/workflows/firebase_internal_testing.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           java-version: "${{env.java_version}}"
           distribution: corretto
-          cache: gradle
 
       - name: Check if build version matches the tag
         run: |

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -36,7 +36,6 @@ jobs:
         with:
           java-version: "${{env.java_version}}"
           distribution: corretto
-          cache: gradle
 
       - name: Check if build version matches the tag
         run: |


### PR DESCRIPTION
## Purpose

Get rid of Gradle cache in build pipelines. Its upload is slow and it never hits.

## Changes

- Disable Gradle cache for all the build pipelines

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.