### PR TITLE
WAL2-79 Do not queue all WalletConnect requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 - Revealing identity attributes when creating an account
 
 ### Fixed
-
 - An issue where signing a text message through WalletConnect did not work
 - An issue where a dApp could request to get a transaction signed by a different account than the one chosen for the WalletConnect session
 - Crashing when received unexpected error from an identity provider
@@ -29,6 +28,7 @@
 - Inability to search for CIS-2 token by ID on contracts with lots of tokens
 - When managing CIS-2 tokens, removing all of them when only unselecting the visible ones
 - Composing a letter with a malformed recipient when clicking the support email on the About screen
+- Possibility of spamming the app with WalletConnect requests from a malfunctioning dApp
 
 ### Changed
 - Suggest running a recovery when facing account or identity creation errors

--- a/app/src/main/java/com/concordium/wallet/ui/walletconnect/WalletConnectViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/walletconnect/WalletConnectViewModel.kt
@@ -48,6 +48,7 @@ import com.concordium.wallet.data.walletconnect.TransactionSuccess
 import com.concordium.wallet.extension.collect
 import com.concordium.wallet.ui.walletconnect.WalletConnectViewModel.Companion.REQUEST_METHOD_SIGN_AND_SEND_TRANSACTION
 import com.concordium.wallet.ui.walletconnect.WalletConnectViewModel.Companion.REQUEST_METHOD_SIGN_MESSAGE
+import com.concordium.wallet.ui.walletconnect.WalletConnectViewModel.Companion.REQUEST_METHOD_VERIFIABLE_PRESENTATION
 import com.concordium.wallet.ui.walletconnect.WalletConnectViewModel.State
 import com.concordium.wallet.ui.walletconnect.delegate.LoggingWalletConnectCoreDelegate
 import com.concordium.wallet.ui.walletconnect.delegate.LoggingWalletConnectWalletDelegate
@@ -577,7 +578,7 @@ private constructor(
         }
 
         if (state is State.Idle) {
-            // Only handle the request if doing anything else.
+            // Only handle the request if not doing anything else.
             // Otherwise, the request will be handled as a pending one
             // once the current affair is finished.
             handleSessionRequest(
@@ -588,10 +589,30 @@ private constructor(
                 peerMetadata = sessionRequestPeerMetadata
             )
         } else {
-            Log.d(
-                "session_request_to_be_handled_later:" +
-                        "\nrequestId=${sessionRequest.request.id}"
-            )
+            // We do not want to queue more than one request for each topic (dApp),
+            // as the dApp may be broken and spam requests.
+            // At this point, topic pending requests may already contain this sessionRequest.
+            val topicPendingRequests = SignClient.getPendingRequests(sessionRequest.topic)
+            if (topicPendingRequests.isEmpty() || topicPendingRequests.size == 1) {
+                Log.d(
+                    "session_request_to_be_handled_later:" +
+                            "\nrequestId=${sessionRequest.request.id}" +
+                            "\nrequestTopic=${sessionRequest.topic}"
+                )
+            } else {
+                Log.w(
+                    "received_next_session_request_in_topic_before_current_is_handled:" +
+                            "\nrequestId=${sessionRequest.request.id}" +
+                            "\nrequestTopic=${sessionRequest.topic}"
+                )
+
+                respondError(
+                    message = "Subsequent requests are rejected until the current one is handled: " +
+                            topicPendingRequests.first().requestId,
+                    sessionRequestId = sessionRequest.request.id,
+                    sessionRequestTopic = sessionRequest.topic,
+                )
+            }
         }
     }
 
@@ -1581,7 +1602,11 @@ private constructor(
         }
     }
 
-    private fun respondError(message: String) {
+    private fun respondError(
+        message: String,
+        sessionRequestId: Long = this.sessionRequestId,
+        sessionRequestTopic: String = this.sessionRequestTopic,
+    ) {
         handledRequests += sessionRequestId
 
         SignClient.respond(


### PR DESCRIPTION
## Purpose

Do not just queue all the incoming WalletConnect requests. To eliminate the possibility of spamming the app with WalletConnect requests from a malfunctioning dApp, allow only one queued request per dApp.

## Changes

- Do not queue more than one WC request per dApp
- Only handle incoming WC requests from Idle state
- Actualize WalletConnect internal docs

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
