### PR TITLE
Fix WalletConnect stuck loading

### DIFF
--- a/app/src/main/java/com/concordium/wallet/ui/walletconnect/WalletConnectViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/walletconnect/WalletConnectViewModel.kt
@@ -577,7 +577,7 @@ private constructor(
             return
         }
 
-        if (state is State.Idle) {
+        if (state is State.Idle || state is State.WaitingForSessionRequest) {
             // Only handle the request if not doing anything else.
             // Otherwise, the request will be handled as a pending one
             // once the current affair is finished.


### PR DESCRIPTION
## Purpose

Fix WalletConnect stuck loading, which used to happen if the app is opened through a link.
The bug was introduced after recent changes to WalletConnect request queuing.

## Changes

- Do not queue WalletConnect request if currently waiting for one;

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
