### PR TITLE
WAL2-85 Fix crash on validator setup flow

### DIFF
--- a/app/src/main/java/com/concordium/wallet/data/model/SimpleFraction.kt
+++ b/app/src/main/java/com/concordium/wallet/data/model/SimpleFraction.kt
@@ -1,7 +1,7 @@
 package com.concordium.wallet.data.model
 
+import java.io.Serializable
 import java.math.BigInteger
-import java.math.MathContext
 
 /**
  * A fraction defined as 2 integers:
@@ -10,13 +10,8 @@ import java.math.MathContext
  *  –
  *  D
  * ```
- *
- * @see toBigDecimal
  */
-data class SimpleFraction(
+class SimpleFraction(
     val numerator: BigInteger,
     val denominator: BigInteger,
-) {
-    fun toBigDecimal() =
-        numerator.toBigDecimal().divide(denominator.toBigDecimal(), MathContext.UNLIMITED)
-}
+): Serializable


### PR DESCRIPTION
## Purpose

The crash was caused by missing Serializable marker on SimpleFraction, introduced with WC cost estimation fix.

## Changes

- Add missing Serializable marker on SimpleFraction

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
