### PR TITLE
WAL2-87 Fix ability to create a new file-based wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Support for WalletConnect binary messages signing
 
+### Fixed
+- A way to get into an empty wallet without confirming the seed phrase
+
 ## [1.0.0] - 2022-04-24
 
 ### Added

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android {
     def versionMajor = 1
     def versionMinor = 1
     def versionPatch = 0
-    def versionMeta = "-qa.1"
-    def versionCodeIncremental = 1373
+    def versionMeta = "-qa.2"
+    def versionCodeIncremental = 1374
 
     compileSdkVersion 34
 

--- a/app/src/main/java/com/concordium/wallet/ui/MainActivity.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/MainActivity.kt
@@ -23,7 +23,6 @@ import com.concordium.wallet.ui.tokens.provider.ProvidersOverviewFragment
 import com.concordium.wallet.ui.walletconnect.WalletConnectView
 import com.concordium.wallet.ui.walletconnect.WalletConnectViewModel
 import com.concordium.wallet.ui.welcome.WelcomeActivity
-import com.concordium.wallet.ui.welcome.WelcomePromoActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 class MainActivity : BaseActivity(R.layout.activity_main, R.string.accounts_overview_title),
@@ -87,8 +86,12 @@ class MainActivity : BaseActivity(R.layout.activity_main, R.string.accounts_over
             builder.setCancelable(false)
             builder.create().show()
         } else {
-            if (viewModel.shouldShowAuthentication()) {
-                showAuthenticationOrContinueSetup()
+            if (viewModel.shouldShowPasswordSetup() || viewModel.shouldShowInitialSetup()) {
+                finishAffinity()
+                startActivity(Intent(this, WelcomeActivity::class.java))
+            } else if (viewModel.shouldShowAuthentication()) {
+                val intent = Intent(this, AuthLoginActivity::class.java)
+                startActivity(intent)
             } else {
                 viewModel.setInitialStateIfNotSet()
 
@@ -213,19 +216,6 @@ class MainActivity : BaseActivity(R.layout.activity_main, R.string.accounts_over
 
     //region Control/UI
     // ************************************************************
-
-    private fun showAuthenticationOrContinueSetup() {
-        if (viewModel.shouldShowPasswordSetup()) {
-            finishAffinity()
-            startActivity(Intent(this, WelcomeActivity::class.java))
-        } else if (viewModel.shouldShowInitialSetup()) {
-            finishAffinity()
-            startActivity(Intent(this, WelcomePromoActivity::class.java))
-        } else {
-            val intent = Intent(this, AuthLoginActivity::class.java)
-            startActivity(intent)
-        }
-    }
 
     override fun loggedOut() {
     }

--- a/app/src/main/java/com/concordium/wallet/ui/account/accountsoverview/AccountsOverviewFragment.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/account/accountsoverview/AccountsOverviewFragment.kt
@@ -14,6 +14,7 @@ import com.concordium.wallet.App
 import com.concordium.wallet.R
 import com.concordium.wallet.core.arch.EventObserver
 import com.concordium.wallet.data.model.Token
+import com.concordium.wallet.data.preferences.AuthPreferences
 import com.concordium.wallet.data.preferences.Preferences
 import com.concordium.wallet.data.room.Account
 import com.concordium.wallet.data.util.CurrencyUtil
@@ -27,6 +28,7 @@ import com.concordium.wallet.ui.base.BaseFragment
 import com.concordium.wallet.ui.cis2.SendTokenActivity
 import com.concordium.wallet.ui.identity.identityproviderlist.IdentityProviderListActivity
 import com.concordium.wallet.ui.more.export.ExportActivity
+import com.concordium.wallet.util.KeyCreationVersion
 import com.concordium.wallet.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -44,6 +46,7 @@ class AccountsOverviewFragment : BaseFragment() {
     private lateinit var viewModel: AccountsOverviewViewModel
     private lateinit var mainViewModel: MainViewModel
     private lateinit var accountAdapter: AccountAdapter
+    private lateinit var keyCreationVersion: KeyCreationVersion
 
     //region Lifecycle
     // ************************************************************
@@ -52,6 +55,7 @@ class AccountsOverviewFragment : BaseFragment() {
         super.onCreate(savedInstanceState)
 
         setHasOptionsMenu(true)
+        keyCreationVersion = KeyCreationVersion(AuthPreferences(requireContext()))
     }
 
     override fun onCreateView(
@@ -166,10 +170,12 @@ class AccountsOverviewFragment : BaseFragment() {
         binding.createAccountButton.visibility = View.GONE
 
         binding.createIdentityButton.setOnClickListener {
+            viewModel.checkUsingV1KeyCreation()
             goToFirstIdentityCreation()
         }
 
         binding.createAccountButton.setOnClickListener {
+            viewModel.checkUsingV1KeyCreation()
             gotoCreateAccount()
         }
 

--- a/app/src/main/java/com/concordium/wallet/ui/account/accountsoverview/AccountsOverviewViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/account/accountsoverview/AccountsOverviewViewModel.kt
@@ -12,10 +12,12 @@ import com.concordium.wallet.core.arch.Event
 import com.concordium.wallet.data.AccountRepository
 import com.concordium.wallet.data.IdentityRepository
 import com.concordium.wallet.data.model.TransactionStatus
+import com.concordium.wallet.data.preferences.AuthPreferences
 import com.concordium.wallet.data.room.AccountWithIdentity
 import com.concordium.wallet.data.room.WalletDatabase
 import com.concordium.wallet.ui.account.common.accountupdater.AccountUpdater
 import com.concordium.wallet.ui.account.common.accountupdater.TotalBalancesData
+import com.concordium.wallet.util.KeyCreationVersion
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.math.BigInteger
@@ -52,6 +54,7 @@ class AccountsOverviewViewModel(application: Application) : AndroidViewModel(app
     private val accountRepository: AccountRepository
     private val accountUpdater = AccountUpdater(application, viewModelScope)
     val accountListLiveData: LiveData<List<AccountWithIdentity>>
+    private val keyCreationVersion: KeyCreationVersion
 
     enum class State {
         NO_IDENTITIES, NO_ACCOUNTS, DEFAULT
@@ -82,6 +85,7 @@ class AccountsOverviewViewModel(application: Application) : AndroidViewModel(app
                 _errorLiveData.postValue(Event(stringRes))
             }
         })
+        keyCreationVersion = KeyCreationVersion(AuthPreferences(application))
     }
 
     fun initialize() {
@@ -166,4 +170,9 @@ class AccountsOverviewViewModel(application: Application) : AndroidViewModel(app
         }
         return false
     }
+
+    fun checkUsingV1KeyCreation() =
+        check(keyCreationVersion.useV1) {
+            "Key creation V1 (seed-based) must be used to perform this action"
+        }
 }

--- a/app/src/main/java/com/concordium/wallet/ui/identity/identityproviderlist/IdentityProviderListActivity.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/identity/identityproviderlist/IdentityProviderListActivity.kt
@@ -47,6 +47,11 @@ class IdentityProviderListActivity : BaseActivity(
             this,
             ViewModelProvider.AndroidViewModelFactory.getInstance(application)
         )[IdentityProviderListViewModel::class.java]
+
+        if (showForFirstIdentity) {
+            viewModel.checkUsingV1KeyCreation()
+        }
+
         viewModel.waitingLiveData.observe(this) { waiting ->
             waiting?.let {
                 showWaiting(waiting || viewModel.waitingGlobalData.value!!)

--- a/app/src/main/java/com/concordium/wallet/ui/identity/identityproviderlist/IdentityProviderListViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/identity/identityproviderlist/IdentityProviderListViewModel.kt
@@ -275,4 +275,9 @@ class IdentityProviderListViewModel(application: Application) : AndroidViewModel
             )
         }
     }
+
+    fun checkUsingV1KeyCreation() =
+        check(keyCreationVersion.useV1) {
+            "Key creation V1 (seed-based) must be used to perform this action"
+        }
 }


### PR DESCRIPTION
## Purpose

Fix a way to get into an empty wallet without confirming the seed phrase, leading to creation of a new file-based wallet.

## Changes

- Deny creation of the first identity if V0 key creation is in use;
- Fix not continuing initial setup if no auth needed;

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
