### PR TITLE
Actualize "Watch video" link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Support for WalletConnect binary messages signing
 - Ability to paste the phrase from the clipboard when importing a wallet
 
+### Changed
+- The "Watch video" link on the welcome screen now opens the account creation tutorial
+
 ### Fixed
 - A way to get into an empty wallet without confirming the seed phrase
 

--- a/app/src/main/java/com/concordium/wallet/ui/welcome/WelcomePromoViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/welcome/WelcomePromoViewModel.kt
@@ -21,7 +21,7 @@ class WelcomePromoViewModel(application: Application) : AndroidViewModel(applica
         get() = !App.appCore.session.hasSetupPassword
     val accountActivationReward = BigInteger("1000000000")
     val aiAssistantUrl = "https://www.concordium.com/contact"
-    val videosUrl = "https://www.youtube.com/@ConcordiumNet/videos"
+    val videosUrl = "https://www.youtube.com/watch?v=UQPPqXO7hZw&list=PLK_gvUmWN_G_x_63SZswz8ZEK-UqPPZjp&index=3"
 
     fun initialize() {
         App.appCore.session.startedInitialSetup()


### PR DESCRIPTION
## Purpose

The "Watch video" link on the welcome screen now opens the account creation tutorial.

## Changes

- The "Watch video" link on the welcome screen now opens the account creation tutorial.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
