### PR TITLE
Do not consider read-only accs for unshielding

### DIFF
--- a/app/src/main/java/com/concordium/wallet/data/room/Account.kt
+++ b/app/src/main/java/com/concordium/wallet/data/room/Account.kt
@@ -146,6 +146,10 @@ data class Account(
     }
 
     fun mayNeedUnshielding(): Boolean {
+        if (finalizedEncryptedBalance == null || readOnly) {
+            return false
+        }
+
         val isShieldedBalanceUnknown = encryptedBalanceStatus == ShieldedAccountEncryptionStatus.ENCRYPTED
                 || encryptedBalanceStatus == ShieldedAccountEncryptionStatus.PARTIALLYDECRYPTED
         val isShieldedBalancePositive = encryptedBalanceStatus == ShieldedAccountEncryptionStatus.DECRYPTED


### PR DESCRIPTION
## Purpose

- Fix showing read-only accounts on the unshielding screen.

## Changes

- Do not consider read-only accounts for unshielding.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
