### PR TITLE
AND-31 Show unshielding notice once per app start

### DIFF
--- a/app/src/main/java/com/concordium/wallet/core/authentication/Session.kt
+++ b/app/src/main/java/com/concordium/wallet/core/authentication/Session.kt
@@ -30,6 +30,9 @@ class Session {
     val isLoggedIn: LiveData<Boolean>
         get() = _isLoggedIn
 
+    // The notice must be shown once per app start.
+    private var isUnshieldingNoticeShown = false
+
     constructor(context: Context) {
         authPreferences = AuthPreferences(context)
         hasSetupPassword = authPreferences.getHasSetupUser()
@@ -54,12 +57,11 @@ class Session {
     }
 
     fun unshieldingNoticeShown() {
-        authPreferences.setUnshieldingNoticeShown(true)
+        isUnshieldingNoticeShown = true
     }
 
-    fun isUnshieldingNoticeShown():Boolean {
-        return authPreferences.getUnshieldingNoticeShown()
-    }
+    fun isUnshieldingNoticeShown(): Boolean =
+        isUnshieldingNoticeShown
 
     fun hasSetupPassword(passcodeUsed: Boolean = false) {
         _isLoggedIn.value = true

--- a/app/src/main/java/com/concordium/wallet/data/preferences/AuthPreferences.kt
+++ b/app/src/main/java/com/concordium/wallet/data/preferences/AuthPreferences.kt
@@ -28,15 +28,6 @@ class AuthPreferences(val context: Context) :
         const val PREFKEY_ENCRYPTED_SEED_ENTROPY_HEX =
             "PREFKEY_ENCRYPTED_SEED_ENTROPY_HEX"
         const val PREFKEY_LEGACY_SEED_HEX_ENCRYPTED = "SEED_PHRASE_ENCRYPTED"
-        const val PREFKEY_UNSHIELDING_NOTICE_SHOWN = "UNSHIELDING_NOTICE_SHOWN"
-    }
-
-    fun setUnshieldingNoticeShown(value: Boolean) {
-        setBoolean(PREFKEY_UNSHIELDING_NOTICE_SHOWN, value)
-    }
-
-    fun getUnshieldingNoticeShown(): Boolean {
-        return getBoolean(PREFKEY_UNSHIELDING_NOTICE_SHOWN, false)
     }
 
     fun setHasSetupUser(value: Boolean) {


### PR DESCRIPTION
## Purpose

Show unshielding notice once per app start instead of showing it once at all.

## Changes

- Store unshielding notice shown flag in the session

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
