### PR TITLE
AND-30 Do not finish unshielding screens on auth cancel

### DIFF
--- a/app/src/main/java/com/concordium/wallet/ui/more/unshielding/UnshieldingAccountsActivity.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/more/unshielding/UnshieldingAccountsActivity.kt
@@ -60,7 +60,6 @@ class UnshieldingAccountsActivity : BaseActivity(
             override fun onUnhandledEvent(value: Boolean) {
                 showAuthentication(
                     activity = this@UnshieldingAccountsActivity,
-                    onCanceled = ::finish,
                     onAuthenticated = viewModel::onAuthenticated
                 )
             }

--- a/app/src/main/java/com/concordium/wallet/ui/more/unshielding/UnshieldingActivity.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/more/unshielding/UnshieldingActivity.kt
@@ -62,7 +62,6 @@ class UnshieldingActivity : BaseActivity(
             override fun onUnhandledEvent(value: Boolean) {
                 showAuthentication(
                     activity = this@UnshieldingActivity,
-                    onCanceled = ::finish,
                     onAuthenticated = viewModel::onAuthenticated
                 )
             }


### PR DESCRIPTION
## Purpose

After cancel, app should route to the parent view.

## Changes

- Do not finish unshielding screens on auth cancel

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
