### PR TITLE
AND-34 Add missing button at the end of the unshielding flow

### DIFF
--- a/app/src/main/java/com/concordium/wallet/ui/more/unshielding/UnshieldingAccountsActivity.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/more/unshielding/UnshieldingAccountsActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.get
 import com.concordium.wallet.R
@@ -34,6 +35,7 @@ class UnshieldingAccountsActivity : BaseActivity(
 
         initViewModel()
         initList()
+        initButtons()
 
         hideActionBarBack(isVisible = true)
     }
@@ -70,6 +72,14 @@ class UnshieldingAccountsActivity : BaseActivity(
                 openUnshielding(value)
             }
         })
+
+        viewModel.isDoneButtonVisibleLiveData.observe(this, binding.doneButton::isVisible::set)
+    }
+
+    private fun initButtons() {
+        binding.doneButton.setOnClickListener {
+            finish()
+        }
     }
 
     private fun initList() {

--- a/app/src/main/java/com/concordium/wallet/ui/more/unshielding/UnshieldingAccountsViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/more/unshielding/UnshieldingAccountsViewModel.kt
@@ -46,10 +46,18 @@ class UnshieldingAccountsViewModel(application: Application) : AndroidViewModel(
     private val _openUnshieldingLiveData = MutableLiveData<Event<String>>()
     val openUnshieldingLiveData: LiveData<Event<String>> = _openUnshieldingLiveData
 
+    private val _isDoneButtonVisibleLiveData = MutableLiveData(false)
+    val isDoneButtonVisibleLiveData: LiveData<Boolean> = _isDoneButtonVisibleLiveData
+
     private lateinit var accountToUnshield: Account
 
     init {
         findAccountsMayNeedUnshielding()
+
+        _listItemsLiveData.observeForever { listItems ->
+            _isDoneButtonVisibleLiveData.value =
+                listItems.all(UnshieldingAccountListItem::isUnshielded)
+        }
     }
 
     private fun findAccountsMayNeedUnshielding() = viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/concordium/wallet/ui/more/unshielding/UnshieldingViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/more/unshielding/UnshieldingViewModel.kt
@@ -268,24 +268,6 @@ class UnshieldingViewModel(application: Application) : AndroidViewModel(applicat
     ) {
         var newSelfEncryptedAmount: String? = null
 
-        if (createTransferOutput.addedSelfEncryptedAmount != null) {
-            account.finalizedEncryptedBalance?.let { encBalance ->
-                val newEncryptedAmount = App.appCore.cryptoLibrary.combineEncryptedAmounts(
-                    createTransferOutput.addedSelfEncryptedAmount,
-                    encBalance.selfAmount
-                ).toString()
-                newSelfEncryptedAmount = newEncryptedAmount
-                val oldDecryptedAmount =
-                    accountUpdater.lookupMappedAmount(encBalance.selfAmount)
-                oldDecryptedAmount?.let {
-                    accountUpdater.saveDecryptedAmount(
-                        newEncryptedAmount,
-                        (it.toBigInteger() + amount).toString()
-                    )
-                }
-            }
-        }
-
         if (createTransferOutput.remaining != null) {
             newSelfEncryptedAmount = createTransferOutput.remaining
             val remainingAmount =

--- a/app/src/main/java/com/concordium/wallet/ui/more/unshielding/UnshieldingViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/more/unshielding/UnshieldingViewModel.kt
@@ -27,6 +27,7 @@ import com.concordium.wallet.data.room.Account
 import com.concordium.wallet.data.room.Transfer
 import com.concordium.wallet.data.room.WalletDatabase
 import com.concordium.wallet.ui.account.common.accountupdater.AccountUpdater
+import com.concordium.wallet.ui.account.common.accountupdater.TotalBalancesData
 import com.concordium.wallet.ui.common.BackendErrorHandler
 import com.concordium.wallet.ui.transaction.sendfunds.SendFundsViewModel
 import com.concordium.wallet.util.DateTimeUtil
@@ -243,9 +244,6 @@ class UnshieldingViewModel(application: Application) : AndroidViewModel(applicat
             amount = amount,
             submissionId = submissionId
         )
-
-        _isUnshieldEnabledLiveData.postValue(true)
-        _waitingLiveData.postValue(false)
     }
 
     private suspend fun submitTransfer(
@@ -266,26 +264,13 @@ class UnshieldingViewModel(application: Application) : AndroidViewModel(applicat
         amount: BigInteger,
         submissionId: String,
     ) {
-        var newSelfEncryptedAmount: String? = null
+        val newSelfEncryptedAmount: String? = createTransferOutput.remaining
 
-        if (createTransferOutput.remaining != null) {
-            newSelfEncryptedAmount = createTransferOutput.remaining
-            val remainingAmount =
-                accountUpdater.decryptAndSaveAmount(
-                    credentialsOutput.encryptionSecretKey,
-                    createTransferOutput.remaining
-                )
-
-            account.finalizedEncryptedBalance?.let { encBalance ->
-                val oldDecryptedAmount =
-                    accountUpdater.lookupMappedAmount(encBalance.selfAmount)
-                oldDecryptedAmount?.let {
-                    accountUpdater.saveDecryptedAmount(
-                        createTransferOutput.remaining,
-                        remainingAmount.toString()
-                    )
-                }
-            }
+        if (newSelfEncryptedAmount != null) {
+            accountUpdater.decryptAndSaveAmount(
+                credentialsOutput.encryptionSecretKey,
+                newSelfEncryptedAmount
+            )
         }
 
         val newTransfer = Transfer(
@@ -308,14 +293,27 @@ class UnshieldingViewModel(application: Application) : AndroidViewModel(applicat
         )
         transferRepository.insert(newTransfer)
 
-        _finishWithResultLiveData.postValue(
-            Event(
-                UnshieldingResult(
-                    unshieldedAmount = amount,
-                    accountAddress = account.address,
+        accountUpdater.setUpdateListener(object : AccountUpdater.UpdateListener {
+            override fun onError(stringRes: Int) {
+                _errorLiveData.postValue(Event(stringRes))
+                _isUnshieldEnabledLiveData.postValue(true)
+                _waitingLiveData.postValue(false)
+            }
+
+            override fun onDone(totalBalances: TotalBalancesData) {
+                _finishWithResultLiveData.postValue(
+                    Event(
+                        UnshieldingResult(
+                            unshieldedAmount = amount,
+                            accountAddress = account.address,
+                        )
+                    )
                 )
-            )
-        )
+            }
+
+            override fun onNewAccountFinalized(accountName: String) {}
+        })
+        accountUpdater.updateForAccount(account)
     }
 
     private fun getBalanceAtDisposal(): BigInteger =

--- a/app/src/main/res/layout/activity_unshielding_accounts.xml
+++ b/app/src/main/res/layout/activity_unshielding_accounts.xml
@@ -41,15 +41,29 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginHorizontal="18dp"
+        android:layout_marginBottom="20dp"
         android:clipToPadding="false"
         android:paddingBottom="24dp"
         android:scrollbars="none"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/done_button"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/divider"
+        app:layout_goneMarginBottom="0dp"
         tools:listitem="@layout/list_item_unshielding_account"
+        tools:visibility="visible" />
+
+    <Button
+        android:id="@+id/done_button"
+        style="@style/CCX_Button_Primary"
+        android:layout_width="match_parent"
+        android:layout_marginHorizontal="18dp"
+        android:layout_marginBottom="20dp"
+        android:gravity="center"
+        android:text="@string/unshielding_accounts_done"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
         tools:visibility="visible" />
 
     <include

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1079,6 +1079,7 @@
     <string name="unshielding_accounts_subtitle">with shielded assets</string>
     <string name="unshielding_accounts_unshield">Unshield</string>
     <string name="unshielding_accounts_unshielded">Unshielded</string>
+    <string name="unshielding_accounts_done">Done, let\'s move on</string>
     <string name="unshielding_shielded_amount">Shielded amount</string>
     <string name="unshielding_estimated_tx_fee">Estimated transaction fee:</string>
     <string name="unshielding_unshield_funds">Unshield funds</string>


### PR DESCRIPTION
## Purpose

Fix missing Done button at the end of the unshielding flow. Ensure the unshielding is not requested right away after all the accounts have been unshielded.

## Changes

- Add Done button to the unshielding accounts screen
- Remove useless added amount check in unshielding
- Run account update when unshielding completes

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
