### PR TITLE
AND-36 Fix adding accounts to the address book with an empty name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Visually increasing the balance after sending CCD instead of decreasing it
+- Adding newly created accounts to the address book with a blank name
 
 ## [1.1.1] - 2024-06-11
 

--- a/app/src/main/java/com/concordium/wallet/data/room/Recipient.kt
+++ b/app/src/main/java/com/concordium/wallet/data/room/Recipient.kt
@@ -12,11 +12,12 @@ data class Recipient(
     var name: String,
     var address: String
 ) : Serializable {
-    fun displayName(): String {
-        if (name.isNullOrEmpty()) {
-            return address
-        } else {
-            return name
-        }
-    }
+    constructor(
+        account: Account,
+        id: Int = 0,
+    ) : this(
+        id = id,
+        name = account.getAccountName(),
+        address = account.address,
+    )
 }

--- a/app/src/main/java/com/concordium/wallet/ui/account/common/NewAccountViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/account/common/NewAccountViewModel.kt
@@ -402,7 +402,7 @@ open class NewAccountViewModel(application: Application) :
         val accountId = accountRepository.insert(account)
         account.id = accountId.toInt()
         // Also save a recipient representing this account
-        recipientRepository.insert(Recipient(0, account.name, account.address))
+        recipientRepository.insert(Recipient(account))
         _gotoAccountCreatedLiveData.postValue(Event(account))
     }
 }

--- a/app/src/main/java/com/concordium/wallet/ui/account/common/accountupdater/AccountUpdater.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/account/common/accountupdater/AccountUpdater.kt
@@ -218,13 +218,7 @@ class AccountUpdater(val application: Application, private val viewModelScope: C
                             updateListener?.onNewAccountFinalized(request.account.name)
 
                             // Add it to the recipient list.
-                            recipientRepository.insert(
-                                Recipient(
-                                    0,
-                                    request.account.name,
-                                    request.account.address
-                                )
-                            )
+                            recipientRepository.insert(Recipient(request.account))
 
                             // Add default CIS-2 fungible tokens for it.
                             defaultFungibleTokensManager.addForAccount(request.account.address)

--- a/app/src/main/java/com/concordium/wallet/ui/common/identity/IdentityUpdater.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/common/identity/IdentityUpdater.kt
@@ -126,13 +126,7 @@ class IdentityUpdater(val application: Application, private val viewModelScope: 
                                             updateListener?.onNewAccountFinalized(account.name)
 
                                             // Add it to the recipient list.
-                                            recipientRepository.insert(
-                                                Recipient(
-                                                    0,
-                                                    account.name,
-                                                    account.address
-                                                )
-                                            )
+                                            recipientRepository.insert(Recipient(account))
 
                                             // Add default CIS-2 fungible tokens for it.
                                             defaultFungibleTokensManager.addForAccount(account.address)

--- a/app/src/main/java/com/concordium/wallet/ui/identity/identityproviderwebview/IdentityProviderWebViewViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/identity/identityproviderwebview/IdentityProviderWebViewViewModel.kt
@@ -278,7 +278,7 @@ class IdentityProviderWebViewViewModel(application: Application) : AndroidViewMo
             credNumber = nextCredNumber
         )
         accountRepository.insert(account)
-        recipientRepository.insert(Recipient(0, account.name, account.address))
+        recipientRepository.insert(Recipient(account))
     }
 
     private fun getIdentityObjectFromProvider(request: IdentityRequest) {

--- a/app/src/main/java/com/concordium/wallet/ui/more/import/ImportViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/more/import/ImportViewModel.kt
@@ -26,7 +26,12 @@ import com.concordium.wallet.data.export.AccountExport
 import com.concordium.wallet.data.export.EncryptedExportData
 import com.concordium.wallet.data.export.ExportData
 import com.concordium.wallet.data.export.IdentityExport
-import com.concordium.wallet.data.model.*
+import com.concordium.wallet.data.model.GlobalParams
+import com.concordium.wallet.data.model.IdentityAttribute
+import com.concordium.wallet.data.model.IdentityStatus
+import com.concordium.wallet.data.model.PossibleAccount
+import com.concordium.wallet.data.model.ShieldedAccountEncryptionStatus
+import com.concordium.wallet.data.model.TransactionStatus
 import com.concordium.wallet.data.room.Account
 import com.concordium.wallet.data.room.Identity
 import com.concordium.wallet.data.room.Recipient
@@ -457,9 +462,7 @@ class ImportViewModel(application: Application) :
                     existingRecipient.address == it.address
                 }
             }
-            .map {
-                Recipient(0, name = it.address.substring(0, 8), address = it.address)
-            }
+            .map(::Recipient)
         recipientRepository.insertAll(readOnlyRecipients)
 
         // Add default fungible tokens for the accounts.

--- a/app/src/main/java/com/concordium/wallet/ui/passphrase/recoverprocess/RecoverProcessViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/passphrase/recoverprocess/RecoverProcessViewModel.kt
@@ -32,7 +32,6 @@ import com.concordium.wallet.data.room.IdentityDao
 import com.concordium.wallet.data.room.IdentityWithAccounts
 import com.concordium.wallet.data.room.Recipient
 import com.concordium.wallet.data.room.WalletDatabase
-import com.concordium.wallet.ui.account.common.accountupdater.AccountUpdater
 import com.concordium.wallet.ui.cis2.defaults.DefaultFungibleTokensManager
 import com.concordium.wallet.ui.cis2.defaults.DefaultTokensManagerFactory
 import com.concordium.wallet.ui.common.BackendErrorHandler
@@ -352,7 +351,7 @@ class RecoverProcessViewModel(application: Application) : AndroidViewModel(appli
                 if (accountRepository.findByAddress(account.address) == null) {
                     accountRepository.insert(account)
                     if (recipientRepository.getRecipientByAddress(account.address) == null) {
-                        recipientRepository.insert(Recipient(0, account.name, account.address))
+                        recipientRepository.insert(Recipient(account))
                     }
                     defaultFungibleTokensManager.addForAccount(account.address)
 


### PR DESCRIPTION
## Purpose

Fix adding accounts to the address book with an empty name

## Changes

- If adding a recipient automatically created from an account, use the name getter with fallback to avoid empty names

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
