### PR TITLE
AND-61 Explicitly allow company ID in ID providers request

### DIFF
--- a/app/src/main/java/com/concordium/wallet/data/backend/ProxyBackend.kt
+++ b/app/src/main/java/com/concordium/wallet/data/backend/ProxyBackend.kt
@@ -106,7 +106,10 @@ interface ProxyBackend {
     fun getIdentityProviderInfo(): Call<ArrayList<IdentityProvider>>
 
     @GET("v1/ip_info")
-    fun getV1IdentityProviderInfo(): Call<ArrayList<IdentityProvider>>
+    fun getV1IdentityProviderInfo(
+        @Query("company")
+        includeCompanyId: Boolean = true,
+    ): Call<ArrayList<IdentityProvider>>
 
     @GET("v0/global")
     fun getGlobalInfo(): Call<GlobalParamsWrapper>

--- a/app/src/main/java/com/concordium/wallet/data/backend/ProxyBackend.kt
+++ b/app/src/main/java/com/concordium/wallet/data/backend/ProxyBackend.kt
@@ -105,11 +105,8 @@ interface ProxyBackend {
     @GET("v0/ip_info")
     fun getIdentityProviderInfo(): Call<ArrayList<IdentityProvider>>
 
-    @GET("v1/ip_info")
-    fun getV1IdentityProviderInfo(
-        @Query("company")
-        includeCompanyId: Boolean = true,
-    ): Call<ArrayList<IdentityProvider>>
+    @GET("v2/ip_info")
+    fun getV2IdentityProviderInfo(): Call<ArrayList<IdentityProvider>>
 
     @GET("v0/global")
     fun getGlobalInfo(): Call<GlobalParamsWrapper>

--- a/app/src/main/java/com/concordium/wallet/data/backend/repository/IdentityProviderRepository.kt
+++ b/app/src/main/java/com/concordium/wallet/data/backend/repository/IdentityProviderRepository.kt
@@ -14,15 +14,15 @@ class IdentityProviderRepository {
     private val backend = App.appCore.getProxyBackend()
 
     fun getIdentityProviderInfo(
-        useV1: Boolean,
+        useLegacy: Boolean,
         success: (ArrayList<IdentityProvider>) -> Unit,
         failure: ((Throwable) -> Unit)?
     ): BackendRequest<ArrayList<IdentityProvider>> {
         val call =
-            if (useV1)
-                backend.getV1IdentityProviderInfo()
-            else
+            if (useLegacy)
                 backend.getIdentityProviderInfo()
+            else
+                backend.getV2IdentityProviderInfo()
         call.enqueue(object : BackendCallback<ArrayList<IdentityProvider>>() {
 
             override fun onResponseData(response: ArrayList<IdentityProvider>) {

--- a/app/src/main/java/com/concordium/wallet/ui/identity/identityproviderlist/IdentityProviderListViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/identity/identityproviderlist/IdentityProviderListViewModel.kt
@@ -88,7 +88,7 @@ class IdentityProviderListViewModel(application: Application) : AndroidViewModel
         _waitingLiveData.value = true
         identityProviderInfoRequest?.dispose()
         identityProviderInfoRequest = repository.getIdentityProviderInfo(
-            useV1 = keyCreationVersion.useV1,
+            useLegacy = !keyCreationVersion.useV1,
             {
                 _identityProviderList.value = it
                 _waitingLiveData.value = false

--- a/app/src/main/java/com/concordium/wallet/ui/passphrase/recoverprocess/RecoverProcessViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/passphrase/recoverprocess/RecoverProcessViewModel.kt
@@ -125,7 +125,7 @@ class RecoverProcessViewModel(application: Application) : AndroidViewModel(appli
 
     private fun getIdentityProviderInfo() {
         identityProvidersRequest = IdentityProviderRepository().getIdentityProviderInfo(
-            useV1 = true,
+            useLegacy = false,
             { identityProviders ->
                 this.identityProviders =
                     identityProviders.filterNot { it.ipInfo.ipDescription.name == "instant_fail_provider" } as ArrayList<IdentityProvider>


### PR DESCRIPTION
## Purpose

Only show Global FinReg company ID provider when the wallet is compatible.

## Changes

- Replace V1 `ip_info` endpoint with V2
- Change `useV1` flag in identity provider repo to `useLegacy` to avoid V1-V2 confusion 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
