### PR TITLE
Fix showing 'null' decimals on token details

### DIFF
--- a/app/src/main/java/com/concordium/wallet/data/util/CurrencyUtil.kt
+++ b/app/src/main/java/com/concordium/wallet/data/util/CurrencyUtil.kt
@@ -67,15 +67,8 @@ object CurrencyUtil {
         return strBuilder.toString().removeSuffix(separator.toString())
     }
 
-    fun toGTUValue(stringValue: String, token: Token?): BigInteger? {
-        var decimals = 0
-        token?.let {
-            it.metadata?.decimals?.let { tokenDecimals ->
-                decimals = tokenDecimals
-            }
-        }
-        return toGTUValue(stringValue, decimals)
-    }
+    fun toGTUValue(stringValue: String, token: Token?): BigInteger? =
+        toGTUValue(stringValue, token?.decimals ?: 0)
 
     fun toGTUValue(stringValue: String, decimals: Int = 6): BigInteger? {
         var str = stringValue.replace("Ͼ", "")

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/TokenDetailsActivity.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/TokenDetailsActivity.kt
@@ -95,7 +95,7 @@ class TokenDetailsActivity : BaseActivity(R.layout.activity_token_details) {
                 setOwnership(token, tokenMetadata)
                 setDescription(tokenMetadata)
                 setTicker(tokenMetadata)
-                setDecimals(tokenMetadata)
+                setDecimals(token)
             }
             if (token.isNewlyReceived) {
                 handleNewlyReceivedToken(token)
@@ -222,10 +222,10 @@ class TokenDetailsActivity : BaseActivity(R.layout.activity_token_details) {
         }
     }
 
-    private fun setDecimals(tokenMetadata: TokenMetadata) {
-        if (tokenMetadata.unique != true) {
+    private fun setDecimals(token: Token) {
+        if (!token.isUnique) {
             binding.includeAbout.decimalsHolder.visibility = View.VISIBLE
-            binding.includeAbout.decimals.text = tokenMetadata.decimals.toString()
+            binding.includeAbout.decimals.text = token.decimals.toString()
         }
     }
 

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/manage/ManageTokensSelectionAdapter.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/manage/ManageTokensSelectionAdapter.kt
@@ -73,7 +73,7 @@ class ManageTokensSelectionAdapter(
             val tokenBalance = CurrencyUtil.formatGTU(
                 token.balance,
                 false,
-                token.metadata?.decimals ?: 0
+                token.decimals
             )
             holder.binding.subtitle.text =
                 context.getString(R.string.cis_search_balance, tokenBalance)

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/manage/ManageTokensTokenDetailsFragment.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/manage/ManageTokensTokenDetailsFragment.kt
@@ -51,7 +51,7 @@ class ManageTokensTokenDetailsFragment : Fragment() {
                 setImage(tokenMetadata)
                 setDescription(tokenMetadata)
                 setTicker(tokenMetadata)
-                setDecimals(tokenMetadata)
+                setDecimals(token)
             }
         }
     }
@@ -125,10 +125,10 @@ class ManageTokensTokenDetailsFragment : Fragment() {
         }
     }
 
-    private fun setDecimals(tokenMetadata: TokenMetadata) {
-        if (tokenMetadata.unique != true) {
+    private fun setDecimals(token: Token) {
+        if (!token.isUnique) {
             binding.details.decimalsHolder.visibility = View.VISIBLE
-            binding.details.decimals.text = tokenMetadata.decimals.toString()
+            binding.details.decimals.text = token.decimals.toString()
         }
     }
 }


### PR DESCRIPTION
## Purpose

Fix showing 'null' decimals on token details, an error brought by the CIS-2 notifications feature.

## Changes

- Show 0 instead of 'null' when a token has no decimals in the metadata

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
