### PR TITLE
AND-67 Fix validator setup failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Notifications for CCD and CIS-2 token transactions
 - Concordex exchange and Wert service where CCD can be purchased
 
+### Fixed
+
+- Inability to configure a validator closed for delegation
+
 ## [1.2.0] - 2024-08-27
 
 ### Added

--- a/app/src/main/java/com/concordium/wallet/data/model/BakerDelegationData.kt
+++ b/app/src/main/java/com/concordium/wallet/data/model/BakerDelegationData.kt
@@ -30,7 +30,16 @@ data class BakerDelegationData(
     var energy: Long? = null
     var accountNonce: AccountNonce? = null
     var amount: BigInteger? = null
+    var finalizationCommissionRate: Double? = null
+    var bakingCommissionRate: Double? = null
+    var transactionCommissionRate: Double? = null
     var chainParameters: ChainParameters? = null
+        set(value) {
+            field = value
+            finalizationCommissionRate = value?.finalizationCommissionRange?.max
+            bakingCommissionRate = value?.bakingCommissionRange?.max
+            transactionCommissionRate = value?.transactionCommissionRange?.max
+        }
     var bakerPoolStatus: BakerPoolStatus? = null
     var passiveDelegation: PassiveDelegation? = null
     var cost: BigInteger? = null

--- a/app/src/main/java/com/concordium/wallet/data/model/ChainParameters.kt
+++ b/app/src/main/java/com/concordium/wallet/data/model/ChainParameters.kt
@@ -17,9 +17,7 @@ data class ChainParameters(
     val accountCreationLimit: Int,
     val minimumEquityCapital: BigInteger,
     val bakingCommissionRange: BakingCommissionRange,
-    val bakingCommissionRate: Double? = null,
     val transactionCommissionRange: TransactionCommissionRange,
-    val transactionCommissionRate: Double? = null,
     val finalizationCommissionRange: FinalizationCommissionRange,
     val euroPerEnergy: SimpleFraction,
     @SerializedName("microGTUPerEuro")

--- a/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/baker/BakerRegistrationConfirmationActivity.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/baker/BakerRegistrationConfirmationActivity.kt
@@ -216,21 +216,21 @@ class BakerRegistrationConfirmationActivity : BaseDelegationBakerActivity(
         }
 
         binding.apply {
-            if (viewModel.bakerDelegationData.chainParameters?.transactionCommissionRate != null) {
+            if (viewModel.bakerDelegationData.transactionCommissionRate != null) {
                 transactionFeeTitle.visibility = View.VISIBLE
                 transactionFeeStatus.visibility = View.VISIBLE
                 transactionFeeStatus.text =
-                    percentFormat.format(viewModel.bakerDelegationData.chainParameters?.transactionCommissionRate)
+                    percentFormat.format(viewModel.bakerDelegationData.transactionCommissionRate)
             } else {
                 transactionFeeTitle.visibility = View.GONE
                 transactionFeeStatus.visibility = View.GONE
             }
 
-            if (viewModel.bakerDelegationData.chainParameters?.bakingCommissionRate != null) {
+            if (viewModel.bakerDelegationData.bakingCommissionRate != null) {
                 bakingTitle.visibility = View.VISIBLE
                 bakingStatus.visibility = View.VISIBLE
                 bakingStatus.text =
-                    percentFormat.format(viewModel.bakerDelegationData.chainParameters?.bakingCommissionRate)
+                    percentFormat.format(viewModel.bakerDelegationData.bakingCommissionRate)
             } else {
                 bakingTitle.visibility = View.GONE
                 bakingStatus.visibility = View.GONE

--- a/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/baker/BakerRegistrationOpenActivity.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/baker/BakerRegistrationOpenActivity.kt
@@ -62,8 +62,8 @@ class BakerRegistrationOpenActivity : BaseDelegationBakerActivity(
             ) {
                 true
             } else {
-                viewModel.bakerDelegationData.oldCommissionRates?.transactionCommission != viewModel.bakerDelegationData.chainParameters?.transactionCommissionRate ||
-                        viewModel.bakerDelegationData.oldCommissionRates?.bakingCommission != viewModel.bakerDelegationData.chainParameters?.bakingCommissionRate
+                viewModel.bakerDelegationData.oldCommissionRates?.transactionCommission != viewModel.bakerDelegationData.transactionCommissionRate ||
+                        viewModel.bakerDelegationData.oldCommissionRates?.bakingCommission != viewModel.bakerDelegationData.bakingCommissionRate
             }
         if (gotoNextPage) gotoNextPage()
         else showNoChange()

--- a/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/common/DelegationBakerViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/common/DelegationBakerViewModel.kt
@@ -140,9 +140,8 @@ class DelegationBakerViewModel(application: Application) : AndroidViewModel(appl
     }
 
     fun commissionRatesHasChanged(): Boolean =
-        bakerDelegationData.oldCommissionRates?.bakingCommission != bakerDelegationData.chainParameters?.bakingCommissionRate ||
-                bakerDelegationData.oldCommissionRates?.transactionCommission != bakerDelegationData.chainParameters?.transactionCommissionRate
-
+        bakerDelegationData.oldCommissionRates?.bakingCommission != bakerDelegationData.bakingCommissionRate ||
+                bakerDelegationData.oldCommissionRates?.transactionCommission != bakerDelegationData.transactionCommissionRate
 
     fun openStatusHasChanged(): Boolean {
         return bakerDelegationData.bakerPoolInfo?.openStatus != bakerDelegationData.oldOpenStatus
@@ -529,11 +528,11 @@ class DelegationBakerViewModel(application: Application) : AndroidViewModel(appl
             if (bakerDelegationData.type == REMOVE_BAKER) null else bakerDelegationData.bakerKeys
 
         val transactionFeeCommission =
-            if (bakerDelegationData.type == REGISTER_BAKER || bakerDelegationData.type == CONFIGURE_BAKER || bakerDelegationData.type == UPDATE_BAKER_POOL) bakerDelegationData.chainParameters?.transactionCommissionRate else null
+            if (bakerDelegationData.type == REGISTER_BAKER || bakerDelegationData.type == CONFIGURE_BAKER || bakerDelegationData.type == UPDATE_BAKER_POOL) bakerDelegationData.transactionCommissionRate else null
         val bakingRewardCommission =
-            if (bakerDelegationData.type == REGISTER_BAKER || bakerDelegationData.type == CONFIGURE_BAKER || bakerDelegationData.type == UPDATE_BAKER_POOL) bakerDelegationData.chainParameters?.bakingCommissionRate else null
+            if (bakerDelegationData.type == REGISTER_BAKER || bakerDelegationData.type == CONFIGURE_BAKER || bakerDelegationData.type == UPDATE_BAKER_POOL) bakerDelegationData.bakingCommissionRate else null
         val finalizationRewardCommission =
-            if (bakerDelegationData.type == REGISTER_BAKER || bakerDelegationData.type == CONFIGURE_BAKER || bakerDelegationData.type == UPDATE_BAKER_POOL) bakerDelegationData.chainParameters?.finalizationCommissionRange?.max else null
+            if (bakerDelegationData.type == REGISTER_BAKER || bakerDelegationData.type == CONFIGURE_BAKER || bakerDelegationData.type == UPDATE_BAKER_POOL) bakerDelegationData.finalizationCommissionRate else null
         val transferInput = CreateTransferInput(
             from,
             keys,
@@ -777,9 +776,7 @@ class DelegationBakerViewModel(application: Application) : AndroidViewModel(appl
         transactionRate: Double?,
         bakingRate: Double?,
     ) {
-        bakerDelegationData.chainParameters = bakerDelegationData.chainParameters?.copy(
-            bakingCommissionRate = bakingRate,
-            transactionCommissionRate = transactionRate,
-        )
+        bakerDelegationData.transactionCommissionRate = transactionRate
+        bakerDelegationData.bakingCommissionRate = bakingRate
     }
 }


### PR DESCRIPTION
## Purpose

Fix inability to configure a validator closed for delegation.

## Changes

- Move `bakingCommissionRate` and `transactionCommissionRate` from the `ChainParameters` model to avoid confusion (those fields are not returned by the proxy)
- Use max range value as a rate instead of null if the validator is closed for delegation. Null value caused failure of the transaction

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
