### PR TITLE
Make notification unsubscription work

### DIFF
--- a/app/src/main/java/com/concordium/wallet/data/backend/notifications/NotificationsBackend.kt
+++ b/app/src/main/java/com/concordium/wallet/data/backend/notifications/NotificationsBackend.kt
@@ -1,10 +1,13 @@
 package com.concordium.wallet.data.backend.notifications
 
 import retrofit2.http.Body
+import retrofit2.http.POST
 import retrofit2.http.PUT
-import retrofit2.http.Path
 
 interface NotificationsBackend {
     @PUT("v1/subscription")
     suspend fun updateSubscription(@Body request: UpdateSubscriptionRequest): Result<Boolean>
+
+    @POST("v1/unsubscribe")
+    suspend fun unsubscribe(@Body request: UpdateSubscriptionRequest): Result<Boolean>
 }

--- a/app/src/main/java/com/concordium/wallet/data/backend/notifications/UpdateSubscriptionRequest.kt
+++ b/app/src/main/java/com/concordium/wallet/data/backend/notifications/UpdateSubscriptionRequest.kt
@@ -4,10 +4,10 @@ import com.concordium.wallet.data.model.NotificationsTopic
 import com.google.gson.annotations.SerializedName
 
 class UpdateSubscriptionRequest(
-    @SerializedName("preferences")
-    val preferences: Set<NotificationsTopic>,
-    @SerializedName("accounts")
-    val accounts: Set<String>,
     @SerializedName("device_token")
-    val fcmToken: String
+    val fcmToken: String,
+    @SerializedName("preferences")
+    val preferences: Set<NotificationsTopic> = emptySet(),
+    @SerializedName("accounts")
+    val accounts: Set<String> = emptySet(),
 )


### PR DESCRIPTION
## Purpose

Use the separate endpoint for unsubscription, so the token gets actually removed on the server.

## Changes

- Use the `unsubscrube` endpoint to unsubscribe from all the notifications

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
