### PR TITLE
AND-79 Fix WC crash loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Inability to configure a validator closed for delegation
 - Incorrect state of the account tokens page when there are no tokens
+- Crash caused by a malformed WalletConnect verifiable presentation request
 
 ## [1.2.0] - 2024-08-27
 

--- a/app/src/main/java/com/concordium/wallet/ui/walletconnect/WalletConnectVerifiablePresentationRequestHandler.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/walletconnect/WalletConnectVerifiablePresentationRequestHandler.kt
@@ -81,7 +81,15 @@ class WalletConnectVerifiablePresentationRequestHandler(
         try {
             val wrappedParams =
                 App.appCore.gson.fromJson(params, WalletConnectParamsWrapper::class.java)
-            this.identityProofRequest = UnqualifiedRequest.fromJson(wrappedParams.paramsJson)
+            this.identityProofRequest = UnqualifiedRequest.fromJson(wrappedParams.paramsJson).also {
+                // Manual checks required because the JSON mapper doesn't care.
+                checkNotNull(it.credentialStatements) {
+                    "Credential statements can't be null"
+                }
+                checkNotNull(it.challenge) {
+                    "Challenge can't be null"
+                }
+            }
         } catch (e: Exception) {
             onInvalidRequest("Failed to parse identity proof request parameters: $params", e)
             return

--- a/app/src/main/java/com/concordium/wallet/ui/walletconnect/WalletConnectViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/walletconnect/WalletConnectViewModel.kt
@@ -673,46 +673,70 @@ private constructor(
 
         this@WalletConnectViewModel.sessionRequestAccount = account
 
-        when (method) {
-            REQUEST_METHOD_SIGN_AND_SEND_TRANSACTION ->
-                signTransactionRequestHandler.start(
-                    params = params,
-                    account = sessionRequestAccount,
-                    appMetadata = sessionRequestAppMetadata,
+        if (method !in allowedRequestMethods) {
+            val unsupportedMethodMessage =
+                "Received an unsupported WalletConnect method request: $method"
+
+            Log.e(unsupportedMethodMessage)
+
+            respondError(message = unsupportedMethodMessage)
+
+            mutableEventsFlow.tryEmit(
+                Event.ShowFloatingError(
+                    Error.InvalidRequest
                 )
+            )
 
-            REQUEST_METHOD_SIGN_MESSAGE ->
-                signMessageRequestHandler.start(
-                    params = params,
-                    account = sessionRequestAccount,
-                    appMetadata = sessionRequestAppMetadata,
-                )
+            onSessionRequestHandlingFinished()
 
-            REQUEST_METHOD_VERIFIABLE_PRESENTATION -> {
-                verifiablePresentationRequestHandler.start(
-                    params = params,
-                    account = account,
-                    availableAccounts = getAvailableAccounts(),
-                    appMetadata = sessionRequestAppMetadata,
-                )
-            }
+            return@launch
+        }
 
-            else -> {
-                val unsupportedMethodMessage =
-                    "Received an unsupported WalletConnect method request: $method"
-
-                Log.e(unsupportedMethodMessage)
-
-                respondError(message = unsupportedMethodMessage)
-
-                mutableEventsFlow.tryEmit(
-                    Event.ShowFloatingError(
-                        Error.InvalidRequest
+        // Even though handlers contain specific error handling,
+        // the global try-catch prevents the crash loop
+        // if there is an unexpected error.
+        try {
+            when (method) {
+                REQUEST_METHOD_SIGN_AND_SEND_TRANSACTION ->
+                    signTransactionRequestHandler.start(
+                        params = params,
+                        account = sessionRequestAccount,
+                        appMetadata = sessionRequestAppMetadata,
                     )
-                )
 
-                onSessionRequestHandlingFinished()
+                REQUEST_METHOD_SIGN_MESSAGE ->
+                    signMessageRequestHandler.start(
+                        params = params,
+                        account = sessionRequestAccount,
+                        appMetadata = sessionRequestAppMetadata,
+                    )
+
+                REQUEST_METHOD_VERIFIABLE_PRESENTATION -> {
+                    verifiablePresentationRequestHandler.start(
+                        params = params,
+                        account = account,
+                        availableAccounts = getAvailableAccounts(),
+                        appMetadata = sessionRequestAppMetadata,
+                    )
+                }
+
+                else ->
+                    error("Missing a handler for the allowed method '$method'")
             }
+        } catch (error: Exception) {
+            val unexpectedErrorMessage = "Unexpected error occurred: $error"
+
+            Log.e(unexpectedErrorMessage, error)
+
+            respondError(unexpectedErrorMessage)
+
+            mutableEventsFlow.tryEmit(
+                Event.ShowFloatingError(
+                    Error.InvalidRequest
+                )
+            )
+
+            onSessionRequestHandlingFinished()
         }
     }
 


### PR DESCRIPTION
## Purpose

Fix a crash loop caused by a malformed WalletConnect verifiable presentation request

## Changes

- Check WC ID proof request nullability
- Handle unexpected WC session request handling errors
- Await the WC connection before sending responses

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
