### PR TITLE
Fix processing CCD drop as shielded transfer

### DIFF
--- a/app/src/main/java/com/concordium/wallet/ui/account/accountdetails/AccountDetailsViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/account/accountdetails/AccountDetailsViewModel.kt
@@ -190,8 +190,7 @@ class AccountDetailsViewModel(application: Application) : AndroidViewModel(appli
             submissionId,
             TransactionStatus.RECEIVED,
             TransactionOutcome.UNKNOWN,
-            TransactionType.TRANSFERTOPUBLIC,   //Not really an outgoing public transfer,
-            //but amount is negative so it is listed as incoming positive
+            TransactionType.TRANSFER,
             null,
             0,
             null


### PR DESCRIPTION
## Purpose

Fix increasing shielded balance when requesting a CCD drop on testnet.

## Changes

- Do not process CCD drop as shielded transfer

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
