### PR TITLE
AND-90 Do not show commissions on validator stake update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@
 
 - Optimized user experience during the onboarding process
 
+### Fixed
+
+- Showing incorrect commission rates on the update validator stake update confirmation screen
+
 ## [1.3.0] - 2024-10-18
 
 ### Added
 
 - Notifications for CCD and CIS-2 token transactions
 - Concordex exchange and Wert service where CCD can be purchased
-- Ability to reveal the wallet private key for those 
+- Ability to reveal the wallet private key for those
   having no ability to reveal the seed phrase
 - Ability to use the wallet private key to restore the wallet
 - Support for Protocol 7 – reducing validation/delegation stake no longer locks the whole amount

--- a/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/common/DelegationBakerViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/common/DelegationBakerViewModel.kt
@@ -140,8 +140,9 @@ class DelegationBakerViewModel(application: Application) : AndroidViewModel(appl
     }
 
     fun commissionRatesHasChanged(): Boolean =
-        bakerDelegationData.oldCommissionRates?.bakingCommission != bakerDelegationData.bakingCommissionRate ||
-                bakerDelegationData.oldCommissionRates?.transactionCommission != bakerDelegationData.transactionCommissionRate
+        (bakerDelegationData.type == REGISTER_BAKER || bakerDelegationData.type == CONFIGURE_BAKER || bakerDelegationData.type == UPDATE_BAKER_POOL)
+                && (bakerDelegationData.oldCommissionRates?.bakingCommission != bakerDelegationData.bakingCommissionRate
+                || bakerDelegationData.oldCommissionRates?.transactionCommission != bakerDelegationData.transactionCommissionRate)
 
     fun openStatusHasChanged(): Boolean {
         return bakerDelegationData.bakerPoolInfo?.openStatus != bakerDelegationData.oldOpenStatus


### PR DESCRIPTION
## Purpose

Fix showing incorrect commission rates on the update validator stake update confirmation screen

## Changes

- Do not show commissions on validator stake update

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
