### PR TITLE
Skip onramp account selection/copying for Concordex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 - Showing incorrect commission rates on the update validator stake update confirmation screen
 
+### Changed
+
+- When going to Concordex DEX, there's no need to select or copy account address, 
+ as it is a WalletConnect-based DEX which fetches the wallet data itself.
+
 ## [1.3.0] - 2024-10-18
 
 ### Added

--- a/app/src/main/java/com/concordium/wallet/ui/onramp/CcdOnrampSitesActivity.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/onramp/CcdOnrampSitesActivity.kt
@@ -55,29 +55,38 @@ class CcdOnrampSitesActivity : BaseActivity(
     private fun onSiteClicked(site: CcdOnrampSite) {
         val accountAddress = viewModel.accountAddress
 
-        if (accountAddress != null) {
+        if (site.type == CcdOnrampSite.Type.DEX) {
             OpenCcdOnrampSiteWithAccountUseCase(
                 site = site,
-                accountAddress = accountAddress,
-                onAccountAddressCopied = {
-                    Toast
-                        .makeText(
-                            this,
-                            getString(R.string.template_ccd_onramp_opening_site, site.name),
-                            Toast.LENGTH_SHORT
-                        )
-                        .show()
-                },
+                accountAddress = "",
+                onAccountAddressCopied = { },
                 context = this,
             ).invoke()
         } else {
-            val intent = Intent(this, CcdOnrampAccountsActivity::class.java)
-            intent.putExtras(
-                CcdOnrampAccountsActivity.getBundle(
+            if (accountAddress != null) {
+                OpenCcdOnrampSiteWithAccountUseCase(
                     site = site,
+                    accountAddress = accountAddress,
+                    onAccountAddressCopied = {
+                        Toast
+                            .makeText(
+                                this,
+                                getString(R.string.template_ccd_onramp_opening_site, site.name),
+                                Toast.LENGTH_SHORT
+                            )
+                            .show()
+                    },
+                    context = this,
+                ).invoke()
+            } else {
+                val intent = Intent(this, CcdOnrampAccountsActivity::class.java)
+                intent.putExtras(
+                    CcdOnrampAccountsActivity.getBundle(
+                        site = site,
+                    )
                 )
-            )
-            startActivity(intent)
+                startActivity(intent)
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose

Skip onramp account selection/copying for Concordex

## Changes

- When going to Concordex DEX, there's no need to select or copy account address, 
 as it is a WalletConnect-based DEX which fetches the wallet data itself.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.

