### PR TITLE
AND-121 Fix "Unlock this feature" the accounts screen actions right after wallet recovery

### DIFF
--- a/app/src/main/java/com/concordium/wallet/ui/account/accountsoverview/AccountsOverviewFragment.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/account/accountsoverview/AccountsOverviewFragment.kt
@@ -10,7 +10,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams
-import android.view.animation.AccelerateDecelerateInterpolator
 import android.view.animation.AccelerateInterpolator
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.view.isVisible
@@ -102,13 +101,13 @@ class AccountsOverviewFragment : BaseFragment() {
             }
         }
 
-        baseActivity.hideQrScan(isVisible = true)
-        if (!mainViewModel.hasCompletedOnboarding()) {
-            baseActivity.hideQrScan(isVisible = true) {
+        baseActivity.hideQrScan(isVisible = true) {
+            if (mainViewModel.hasCompletedOnboarding()) {
+                baseActivity.startQrScanner()
+            } else {
                 baseActivity.showUnlockFeatureDialog()
             }
         }
-
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/concordium/wallet/ui/base/BaseActivity.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/base/BaseActivity.kt
@@ -244,7 +244,7 @@ abstract class BaseActivity(
             }
         }
 
-    private fun startQrScanner() {
+    fun startQrScanner() {
         val intent = Intent(applicationContext, ScanQRActivity::class.java)
         intent.putExtra(EXTRA_QR_CONNECT, true)
         scanQrResult.launch(intent)


### PR DESCRIPTION
## Purpose

Make the features available right after wallet recovery.

## Changes

- Fix not scanning QRs immediately after recovery

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
