### PR TITLE
Change notification popup logic

### DIFF
--- a/app/src/main/java/com/concordium/wallet/ui/account/accountsoverview/AccountsOverviewFragment.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/account/accountsoverview/AccountsOverviewFragment.kt
@@ -36,7 +36,6 @@ import com.concordium.wallet.ui.base.BaseActivity
 import com.concordium.wallet.ui.base.BaseFragment
 import com.concordium.wallet.ui.cis2.SendTokenActivity
 import com.concordium.wallet.ui.more.export.ExportActivity
-import com.concordium.wallet.ui.more.notifications.NotificationsPermissionDialog
 import com.concordium.wallet.ui.onboarding.OnboardingFragment
 import com.concordium.wallet.ui.onboarding.OnboardingSharedViewModel
 import com.concordium.wallet.ui.onboarding.OnboardingState
@@ -178,13 +177,6 @@ class AccountsOverviewFragment : BaseFragment() {
                         UnshieldingNoticeDialog().showSingle(
                             childFragmentManager,
                             UnshieldingNoticeDialog.TAG
-                        )
-                    }
-
-                    AccountsOverviewViewModel.DialogToShow.NOTIFICATIONS_PERMISSION -> {
-                        NotificationsPermissionDialog().showSingle(
-                            childFragmentManager,
-                            NotificationsPermissionDialog.TAG,
                         )
                     }
 

--- a/app/src/main/java/com/concordium/wallet/ui/account/accountsoverview/AccountsOverviewViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/account/accountsoverview/AccountsOverviewViewModel.kt
@@ -85,7 +85,6 @@ class AccountsOverviewViewModel(application: Application) : AndroidViewModel(app
 
     enum class DialogToShow {
         UNSHIELDING,
-        NOTIFICATIONS_PERMISSION,
         ;
     }
 
@@ -292,11 +291,6 @@ class AccountsOverviewViewModel(application: Application) : AndroidViewModel(app
             && accountRepository.getAllDone().any(Account::mayNeedUnshielding)
         ) {
             dialogsToShow += DialogToShow.UNSHIELDING
-        }
-
-        // Show notifications permission if never shown.
-        if (!notificationsPreferences.hasEverShownPermissionDialog) {
-            dialogsToShow += DialogToShow.NOTIFICATIONS_PERMISSION
         }
 
         // Show a single dialog if needed.

--- a/app/src/main/java/com/concordium/wallet/ui/welcome/WelcomeActivity.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/welcome/WelcomeActivity.kt
@@ -13,9 +13,12 @@ import com.concordium.wallet.R
 import com.concordium.wallet.core.authentication.Session
 import com.concordium.wallet.data.preferences.TrackingPreferences
 import com.concordium.wallet.databinding.ActivityWelcomeBinding
+import com.concordium.wallet.extension.collectWhenStarted
+import com.concordium.wallet.extension.showSingle
 import com.concordium.wallet.ui.MainActivity
 import com.concordium.wallet.ui.auth.passcode.PasscodeSetupActivity
 import com.concordium.wallet.ui.base.BaseActivity
+import com.concordium.wallet.ui.more.notifications.NotificationsPermissionDialog
 import com.concordium.wallet.uicore.handleUrlClicks
 
 class WelcomeActivity :
@@ -58,6 +61,15 @@ class WelcomeActivity :
 
         if (savedInstanceState == null) {
             App.appCore.tracker.welcomeScreen()
+        }
+
+        viewModel.isNotificationDialogEverShowed.collectWhenStarted(this) {
+            if (it.not()) {
+                NotificationsPermissionDialog().showSingle(
+                    supportFragmentManager,
+                    NotificationsPermissionDialog.TAG,
+                )
+            }
         }
 
         // Subscribe to activation bottom sheet chosen action.

--- a/app/src/main/java/com/concordium/wallet/ui/welcome/WelcomeViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/welcome/WelcomeViewModel.kt
@@ -2,14 +2,29 @@ package com.concordium.wallet.ui.welcome
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
 import com.concordium.wallet.App
+import com.concordium.wallet.data.preferences.NotificationsPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 class WelcomeViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val notificationsPreferences: NotificationsPreferences
+    private val _isNotificationDialogEverShowed = MutableStateFlow(true)
+    val isNotificationDialogEverShowed = _isNotificationDialogEverShowed.asStateFlow()
 
     val shouldSetUpPassword: Boolean
         get() = !App.appCore.session.hasSetupPassword
 
     init {
         App.appCore.session.startedInitialSetup()
+
+        notificationsPreferences = NotificationsPreferences(application)
+        viewModelScope.launch {
+            // Show notifications permission if never shown
+            _isNotificationDialogEverShowed.emit(notificationsPreferences.hasEverShownPermissionDialog)
+        }
     }
 }


### PR DESCRIPTION
## Purpose

Notification Permission popup only appears when user relaunch the App or navigate back to main screen

## Changes

Notification Permission popup has been moved to the WelcomeScreen

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

