### PR TITLE
AND-144 Add Terms and Privacy policy to the About screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Ability to have both file and seed phrase wallets in the app and switch between them
 - Ability to open the Terms and Conditions and the Privacy Policy from the About screen
 
+### Fixed
+
+- Incorrect support email address in some error messages
+
 ### Removed
 
 - Ability to create new accounts and identities in a file wallet.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Incorrect support email address in some error messages
+- Not working links to the documentation on some screens
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Ability to have both file and seed phrase wallets in the app and switch between them
+- Ability to open the Terms and Conditions and the Privacy Policy from the About screen
 
 ### Removed
 

--- a/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/baker/BakerRegistrationOpenActivity.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/baker/BakerRegistrationOpenActivity.kt
@@ -43,10 +43,13 @@ class BakerRegistrationOpenActivity : BaseDelegationBakerActivity(
             }
         }
 
-        binding.openUrlExplain.handleUrlClicks { url ->
+        fun onUrlClicked(url: String) {
             val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
             ContextCompat.startActivity(this, browserIntent, null)
         }
+
+        binding.openUrlExplain.handleUrlClicks(::onUrlClicked)
+        binding.readMoreTextView.handleUrlClicks(::onUrlClicked)
 
         binding.bakerRegistrationOpenContinue.setOnClickListener {
             KeyboardUtil.hideKeyboard(this)

--- a/app/src/main/java/com/concordium/wallet/ui/more/about/AboutActivity.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/more/about/AboutActivity.kt
@@ -26,33 +26,40 @@ class AboutActivity : BaseActivity(
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        binding.aboutContactText.handleUrlClicks { url ->
-            val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-            ContextCompat.startActivity(this, browserIntent, null)
-        }
+        fun onUrlClicked(url: String) = when {
+            url == "#terms" -> {
+                startActivity(Intent(this, WelcomeTermsActivity::class.java))
+            }
 
-        binding.aboutSupportText.handleUrlClicks { url ->
-            val emailIntent = Intent(Intent.ACTION_SENDTO)
-            emailIntent.data = Uri.parse(url)
-            emailIntent.putExtra(Intent.EXTRA_EMAIL, arrayOf(url))
-            try {
-                // start email intent
-                startActivity(Intent.createChooser(emailIntent, getString(R.string.about_support)))
-            } catch (e: Exception) {
-                // Left empty on purpose
+            url.startsWith("mailto") -> {
+                val emailIntent = Intent(Intent.ACTION_SENDTO)
+                emailIntent.data = Uri.parse(url)
+                emailIntent.putExtra(Intent.EXTRA_EMAIL, arrayOf(url))
+                try {
+                    // start email intent
+                    startActivity(
+                        Intent.createChooser(
+                            emailIntent,
+                            getString(R.string.about_support)
+                        )
+                    )
+                } catch (e: Exception) {
+                    // Left empty on purpose
+                }
+            }
+
+            else -> {
+                val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                ContextCompat.startActivity(this, browserIntent, null)
             }
         }
 
         binding.aboutVersionText.text = AppConfig.appVersion
 
-        binding.termsTextView.handleUrlClicks {
-            startActivity(Intent(this, WelcomeTermsActivity::class.java))
-        }
-
-        binding.privacyTextView.handleUrlClicks { url ->
-            val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-            ContextCompat.startActivity(this, browserIntent, null)
-        }
+        binding.aboutContactText.handleUrlClicks(::onUrlClicked)
+        binding.aboutSupportText.handleUrlClicks(::onUrlClicked)
+        binding.termsTextView.handleUrlClicks(::onUrlClicked)
+        binding.privacyTextView.handleUrlClicks(::onUrlClicked)
 
         hideActionBarBack(isVisible = true)
         binding.toolbarLayout.toolbarTitle.setTextAppearance(R.style.CCX_Typography_PageTitle)

--- a/app/src/main/java/com/concordium/wallet/ui/more/about/AboutActivity.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/more/about/AboutActivity.kt
@@ -8,6 +8,7 @@ import com.concordium.wallet.AppConfig
 import com.concordium.wallet.R
 import com.concordium.wallet.databinding.ActivityAboutBinding
 import com.concordium.wallet.ui.base.BaseActivity
+import com.concordium.wallet.ui.welcome.WelcomeTermsActivity
 import com.concordium.wallet.uicore.handleUrlClicks
 
 class AboutActivity : BaseActivity(
@@ -43,6 +44,15 @@ class AboutActivity : BaseActivity(
         }
 
         binding.aboutVersionText.text = AppConfig.appVersion
+
+        binding.termsTextView.handleUrlClicks {
+            startActivity(Intent(this, WelcomeTermsActivity::class.java))
+        }
+
+        binding.privacyTextView.handleUrlClicks { url ->
+            val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+            ContextCompat.startActivity(this, browserIntent, null)
+        }
 
         hideActionBarBack(isVisible = true)
         binding.toolbarLayout.toolbarTitle.setTextAppearance(R.style.CCX_Typography_PageTitle)

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -75,6 +75,34 @@
             android:textColor="@color/ccx_neutral_tint_2"
             tools:text="x.y.z" />
 
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/about_legal"
+            android:textAppearance="@style/CCX_Typography_H2"
+            android:textColor="@color/ccx_neutral_tint_1" />
+
+        <TextView
+            android:id="@+id/terms_text_view"
+            style="@style/CCX_Typography_Body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/about_terms_link"
+            android:textColor="@color/ccx_neutral_tint_2"
+            android:textColorLink="@color/ccx_neutral_tint_2" />
+
+        <TextView
+            android:id="@+id/privacy_text_view"
+            style="@style/CCX_Typography_Body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/about_privacy_link"
+            android:textColor="@color/ccx_neutral_tint_2"
+            android:textColorLink="@color/ccx_neutral_tint_2" />
+
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -306,6 +306,9 @@
     <string name="about_contact">Website</string>
     <string name="about_contact_text">For more info about CryptoX Wallet you can visit <a href="https://concordium.com">concordium.com</a></string>
     <string name="about_version">App Version</string>
+    <string name="about_legal">Legal Information</string>
+    <string name="about_terms_link"><a href="#terms">Terms and Conditions</a></string>
+    <string name="about_privacy_link"><a href="https://www.concordium.com/privacy-policy">Privacy policy</a></string>
     <!-- Import -->
     <string name="import_not_possible_when_using_phrase">File import is not possible when using a secret phrase</string>
     <string name="import_importing_progress">Importing…</string>
@@ -624,7 +627,7 @@
     <string name="delegation_update_subtitle1">Updating your delegation</string>
     <string name="delegation_update_subtitle2">Pay day updates</string>
     <string name="delegation_update_subtitle3">Cooldowns</string>
-  
+
     <string name="delegation_remove_subtitle1">Stop your delegation</string>
 
     <string name="delegation_status_title">Delegation status</string>
@@ -1168,7 +1171,7 @@
     <string name="unlock_feature_title">Unlock this feature</string>
     <string name="unlock_feature_details">To use all features please complete your wallet set-up.</string>
     <string name="unlock_feature_go_back_button">Go back</string>
-    
+
     <string name="onboarding_status_card_title">Your account will be here once your set-up is complete.</string>
     <string name="onboarding_status_card_description_first">Next step: Save your seed phrase</string>
     <string name="onboarding_status_card_description_second">Final step: Verify your identity</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1005,7 +1005,7 @@
     <string name="passcode_use_full_password">Use full password instead</string>
     <string name="passcode_backspace_button">Delete</string>
     <string name="passcode_biometrics_button">Use biometrics</string>
-    <string name="passcode_setup_failed">Failed to set up passcode, please contact \nsupport@concordium.software.com</string>
+    <string name="passcode_setup_failed">Failed to set up passcode, please contact \nsupport@concordium.com</string>
     <string name="passcode_create_setup_biometrics_title">Enable biometrics for next time?</string>
     <string name="passcode_create_setup_biometrics_details">After you log out now, you’ll be able to sign in faster when you come back</string>
     <string name="passcode_create_setup_biometrics_allow">Enable biometrics</string>
@@ -1019,7 +1019,7 @@
     <string name="setup_wallet_seed_phrase_digital_copy">Digital copy</string>
     <string name="setup_wallet_seed_phrase_screenshot">Screenshot</string>
     <string name="setup_wallet_seed_phrase_copied">@string/copied</string>
-    <string name="setup_wallet_failed">Failed to set up the wallet, please contact \nsupport@concordium.software.com</string>
+    <string name="setup_wallet_failed">Failed to set up the wallet, please contact \nsupport@concordium.com</string>
     <string name="saved_seed_phrase_reveal_seed_phrase_copy">Copy to clipboard</string>
     <string name="saved_seed_phrase_reveal_seed_phrase_show">Show seed phrase</string>
     <string name="saved_seed_phrase_reveal_title">@string/your_seed_phrase</string>
@@ -1027,7 +1027,7 @@
     <string name="saved_seed_phrase_reveal_transcribe">Transcribe</string>
     <string name="saved_seed_phrase_reveal_digital_copy">Digital copy</string>
     <string name="saved_seed_phrase_reveal_screenshot">Screenshot</string>
-    <string name="saved_seed_phrase_reveal_failed">Failed to reveal the phrase, please contact \nsupport@concordium.software.com</string>
+    <string name="saved_seed_phrase_reveal_failed">Failed to reveal the phrase, please contact \nsupport@concordium.com</string>
     <string name="saved_seed_reveal_seed_copy">Copy to clipboard</string>
     <string name="saved_seed_reveal_seed_show">Show wallet private key</string>
     <string name="saved_seed_reveal_title">@string/your_wallet_seed</string>
@@ -1035,7 +1035,7 @@
     <string name="saved_seed_reveal_transcribe">Transcribe</string>
     <string name="saved_seed_reveal_copy_and_keep">Copy and keep safe</string>
     <string name="saved_seed_reveal_screenshot">Screenshot</string>
-    <string name="saved_seed_reveal_failed">Failed to reveal the key, please contact \nsupport@concordium.software.com</string>
+    <string name="saved_seed_reveal_failed">Failed to reveal the key, please contact \nsupport@concordium.com</string>
 
     <!-- Identity proofs in WalletConnect -->
     <string name="zero_knowledge_proof">Zero-knowledge proof</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -662,7 +662,7 @@
 
     <string name="delegation_register_delegation_intro">You can delegate to an open pool of your choice, or you can stake using passive delegation.</string>
     <string name="delegation_register_delegation_desc">If you don\'t already know which validator pool you want to delegate an amount to, you can look for one here:\n\n<a href="https://ccdscan.io/staking">https://ccdscan.io/staking</a></string>
-    <string name="delegation_register_delegation_desc_passive">Passive delegation is an alternative to delegation to a specific validator pool that has lower rewards. With passive delegation you do not have to worry about the uptime or quality of a validator node.\n\nFor more info you can visit\n\n<a href="https://developer.concordium.software/en/mainnet/net/concepts/concepts-delegation.html">developer.concordium.software</a></string>
+    <string name="delegation_register_delegation_desc_passive">Passive delegation is an alternative to delegation to a specific validator pool that has lower rewards. With passive delegation you do not have to worry about the uptime or quality of a validator node.\n\nFor more info you can visit\n\n<a href="https://docs.concordium.com/en/mainnet/docs/protocol/concepts-delegation.html">docs.concordium.com</a></string>
     <string name="delegation_register_delegation_pool_id_hint">Enter validator pool ID</string>
     <string name="delegation_register_delegation_pool_id_hint_update">Optional: New validator pool ID</string>
     <string name="delegation_update_delegation_pool_id_baker">Current target: Validator id %1$s</string>
@@ -790,7 +790,7 @@
 
     <string name="baker_registration_open_title">Add validator</string>
     <string name="baker_registration_open_explain">You can choose to add a URL with metadata about your validator. Leave it blank if you don’t have any.</string>
-    <string name="baker_registration_open_read_more">You can read more about the metadata URL on <a href="https://developer.concordium.software">developer.concordium.software</a></string>
+    <string name="baker_registration_open_read_more">You can read more about the metadata URL on <a href="https://docs.concordium.com/en/mainnet/docs/mobile-wallet/add-baker-mw.html">docs.concordium.com</a></string>
     <string name="baker_registration_open_continue">Continue</string>
     <string name="baker_registration_open_url_hint">Paste your metadata URL here</string>
     <string name="baker_registration_open_url_invalid">Please enter a valid HTTP or HTTPS URL</string>


### PR DESCRIPTION
## Purpose

Add ability to see the Terms as well as the Privacy policy once the wallet is set up. Add the corresponding links to the About screen

## Changes

- Added the links to the About screen
- Fixed not clickable links on some screens
- Fixed incorrect support email in some places

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
