### PR TITLE
Submit transactions through proxy

### DIFF
--- a/app/src/main/java/com/concordium/wallet/core/AppCore.kt
+++ b/app/src/main/java/com/concordium/wallet/core/AppCore.kt
@@ -121,6 +121,7 @@ class AppCore(val app: App) {
         return proxyBackendConfig.backend
     }
 
+    @Deprecated("It's better to use ProxyBackend, as it is backed by a reliable node")
     fun getGrpcClient(): ClientV2 {
         return grpcBackendConfig.client
     }

--- a/app/src/main/java/com/concordium/wallet/data/backend/ProxyBackend.kt
+++ b/app/src/main/java/com/concordium/wallet/data/backend/ProxyBackend.kt
@@ -4,7 +4,6 @@ import com.concordium.wallet.data.cryptolib.CreateTransferOutput
 import com.concordium.wallet.data.model.AccountBalance
 import com.concordium.wallet.data.model.AccountKeyData
 import com.concordium.wallet.data.model.AccountNonce
-import com.concordium.wallet.data.model.AccountSubmissionStatus
 import com.concordium.wallet.data.model.AccountTransactions
 import com.concordium.wallet.data.model.BakerPoolStatus
 import com.concordium.wallet.data.model.CIS2Tokens
@@ -17,8 +16,9 @@ import com.concordium.wallet.data.model.IdentityContainer
 import com.concordium.wallet.data.model.IdentityProvider
 import com.concordium.wallet.data.model.PassiveDelegation
 import com.concordium.wallet.data.model.SubmissionData
+import com.concordium.wallet.data.model.SubmissionStatusResponse
 import com.concordium.wallet.data.model.TransactionCost
-import com.concordium.wallet.data.model.TransferSubmissionStatus
+import okhttp3.RequestBody
 import retrofit2.Call
 import retrofit2.Response
 import retrofit2.http.Body
@@ -29,6 +29,12 @@ import retrofit2.http.Query
 
 interface ProxyBackend {
 
+    /**
+     * Submits a transaction serialized as Block item (version, signature, header, payload).
+     */
+    @PUT("v0/submitRawTransaction")
+    suspend fun submitRawTransaction(@Body transactionBytesBody: RequestBody): SubmissionData
+
     @PUT("v0/submitCredential")
     fun submitCredential(@Body credential: CredentialWrapper): Call<SubmissionData>
 
@@ -38,12 +44,6 @@ interface ProxyBackend {
     @GET("v0/bakerPool/{poolId}")
     suspend fun bakerPoolSuspended(@Path("poolId") poolId: String): Response<BakerPoolStatus>
 
-    @GET("v0/submissionStatus/{submissionId}")
-    fun accountSubmissionStatus(@Path("submissionId") submissionId: String): Call<AccountSubmissionStatus>
-
-    @GET("v0/submissionStatus/{submissionId}")
-    suspend fun accountSubmissionStatusSuspended(@Path("submissionId") submissionId: String): AccountSubmissionStatus
-
     @GET("v0/accNonce/{accountAddress}")
     fun accountNonce(@Path("accountAddress") accountAddress: String): Call<AccountNonce>
 
@@ -51,10 +51,10 @@ interface ProxyBackend {
     fun submitTransfer(@Body transfer: CreateTransferOutput): Call<SubmissionData>
 
     @GET("v0/submissionStatus/{submissionId}")
-    fun transferSubmissionStatus(@Path("submissionId") submissionId: String): Call<TransferSubmissionStatus>
+    fun submissionStatus(@Path("submissionId") submissionId: String): Call<SubmissionStatusResponse>
 
     @GET("v0/submissionStatus/{submissionId}")
-    suspend fun transferSubmissionStatusSuspended(@Path("submissionId") submissionId: String): TransferSubmissionStatus
+    suspend fun submissionStatusSuspended(@Path("submissionId") submissionId: String): SubmissionStatusResponse
 
     @GET("v0/transactionCost")
     fun transferCost(

--- a/app/src/main/java/com/concordium/wallet/data/model/AccountSubmissionStatus.kt
+++ b/app/src/main/java/com/concordium/wallet/data/model/AccountSubmissionStatus.kt
@@ -1,5 +1,0 @@
-package com.concordium.wallet.data.model
-
-data class AccountSubmissionStatus(
-    val status: TransactionStatus
-)

--- a/app/src/main/java/com/concordium/wallet/data/model/SubmissionStatusResponse.kt
+++ b/app/src/main/java/com/concordium/wallet/data/model/SubmissionStatusResponse.kt
@@ -2,7 +2,7 @@ package com.concordium.wallet.data.model
 
 import java.math.BigInteger
 
-data class TransferSubmissionStatus(
+data class SubmissionStatusResponse(
     val status: TransactionStatus,
     val outcome: TransactionOutcome?,
     val amount: BigInteger?,

--- a/app/src/main/java/com/concordium/wallet/ui/account/accountdetails/AccountReleaseScheduleViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/account/accountdetails/AccountReleaseScheduleViewModel.kt
@@ -5,9 +5,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
-import com.concordium.wallet.App
 import com.concordium.wallet.core.arch.Event
-import com.concordium.wallet.data.backend.repository.ProxyRepository
 import com.concordium.wallet.data.model.Schedule
 import com.concordium.wallet.data.room.Account
 import kotlinx.coroutines.Dispatchers
@@ -17,10 +15,6 @@ class AccountReleaseScheduleViewModel(application: Application) : AndroidViewMod
 
     lateinit var account: Account
     var isShielded: Boolean = false
-
-    private val proxyRepository = ProxyRepository()
-
-    private val gson = App.appCore.gson
 
     // Transaction state
     private val _waitingLiveData = MutableLiveData<Boolean>()
@@ -38,9 +32,6 @@ class AccountReleaseScheduleViewModel(application: Application) : AndroidViewMod
     private var _scheduledReleasesLiveData = MutableLiveData<List<Schedule>>()
     val scheduledReleasesLiveData: LiveData<List<Schedule>>
         get() = _scheduledReleasesLiveData
-
-    init {
-    }
 
     fun initialize(account: Account, isShielded: Boolean) {
         this.account = account

--- a/app/src/main/java/com/concordium/wallet/ui/account/common/NewAccountViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/account/common/NewAccountViewModel.kt
@@ -19,12 +19,12 @@ import com.concordium.wallet.data.backend.repository.ProxyRepository
 import com.concordium.wallet.data.cryptolib.CreateCredentialInputV1
 import com.concordium.wallet.data.cryptolib.CreateCredentialOutput
 import com.concordium.wallet.data.cryptolib.StorageAccountData
-import com.concordium.wallet.data.model.AccountSubmissionStatus
 import com.concordium.wallet.data.model.CredentialWrapper
 import com.concordium.wallet.data.model.EncryptedData
 import com.concordium.wallet.data.model.GlobalParams
 import com.concordium.wallet.data.model.GlobalParamsWrapper
 import com.concordium.wallet.data.model.SubmissionData
+import com.concordium.wallet.data.model.SubmissionStatusResponse
 import com.concordium.wallet.data.model.TransactionStatus
 import com.concordium.wallet.data.room.Account
 import com.concordium.wallet.data.room.Identity
@@ -50,7 +50,7 @@ open class NewAccountViewModel(application: Application) :
 
     private var globalParamsRequest: BackendRequest<GlobalParamsWrapper>? = null
     private var submitCredentialRequest: BackendRequest<SubmissionData>? = null
-    private var accountSubmissionStatusRequest: BackendRequest<AccountSubmissionStatus>? = null
+    private var accountSubmissionStatusRequest: BackendRequest<SubmissionStatusResponse>? = null
     private var firstAccount: Boolean = false
 
     private var tempData = TempData()

--- a/app/src/main/java/com/concordium/wallet/ui/account/common/accountupdater/AccountUpdater.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/account/common/accountupdater/AccountUpdater.kt
@@ -15,12 +15,11 @@ import com.concordium.wallet.data.backend.repository.ProxyRepository
 import com.concordium.wallet.data.cryptolib.DecryptAmountInput
 import com.concordium.wallet.data.model.AccountBalance
 import com.concordium.wallet.data.model.AccountEncryptedAmount
-import com.concordium.wallet.data.model.AccountSubmissionStatus
 import com.concordium.wallet.data.model.ShieldedAccountEncryptionStatus
+import com.concordium.wallet.data.model.SubmissionStatusResponse
 import com.concordium.wallet.data.model.TransactionOutcome
 import com.concordium.wallet.data.model.TransactionStatus
 import com.concordium.wallet.data.model.TransactionType
-import com.concordium.wallet.data.model.TransferSubmissionStatus
 import com.concordium.wallet.data.room.Account
 import com.concordium.wallet.data.room.EncryptedAmount
 import com.concordium.wallet.data.room.Recipient
@@ -46,12 +45,12 @@ import java.math.BigInteger
 
 class AccountUpdater(val application: Application, private val viewModelScope: CoroutineScope) {
     data class AccountSubmissionStatusRequestData(
-        val deferred: Deferred<AccountSubmissionStatus>,
+        val deferred: Deferred<SubmissionStatusResponse>,
         val account: Account
     )
 
     data class TransferSubmissionStatusRequestData(
-        val deferred: Deferred<TransferSubmissionStatus>,
+        val deferred: Deferred<SubmissionStatusResponse>,
         val transfer: Transfer
     )
 
@@ -198,7 +197,7 @@ class AccountUpdater(val application: Application, private val viewModelScope: C
                         )
                     ) {
                         val deferred = async {
-                            proxyRepository.getAccountSubmissionStatusSuspended(account.submissionId)
+                            proxyRepository.getSubmissionStatus(account.submissionId)
                         }
                         val requestData = AccountSubmissionStatusRequestData(
                             deferred,
@@ -270,7 +269,7 @@ class AccountUpdater(val application: Application, private val viewModelScope: C
                         || transfer.transactionStatus == TransactionStatus.UNKNOWN
                     ) {
                         val deferred = async {
-                            proxyRepository.getTransferSubmissionStatusSuspended(transfer.submissionId)
+                            proxyRepository.getSubmissionStatus(transfer.submissionId)
                         }
                         val requestData = TransferSubmissionStatusRequestData(
                             deferred,

--- a/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/common/DelegationBakerViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/common/DelegationBakerViewModel.kt
@@ -23,7 +23,6 @@ import com.concordium.sdk.transactions.ConfigureBakerTransaction
 import com.concordium.sdk.transactions.ConfigureDelegationPayload
 import com.concordium.sdk.transactions.ConfigureDelegationTransaction
 import com.concordium.sdk.transactions.Expiry
-import com.concordium.sdk.transactions.Hash
 import com.concordium.sdk.transactions.SignerEntry
 import com.concordium.sdk.transactions.TransactionFactory
 import com.concordium.sdk.transactions.TransactionSigner
@@ -707,9 +706,9 @@ class DelegationBakerViewModel(application: Application) : AndroidViewModel(appl
     ) = withContext(Dispatchers.IO) {
 
         val submissionId: String = try {
-            App.appCore.getGrpcClient()
-                .sendTransaction(transaction)
-                .asHex()
+            proxyRepository
+                .submitSdkTransaction(transaction)
+                .submissionId
         } catch (e: Exception) {
             Log.e("Error submitting transaction", e)
             withContext(Dispatchers.Main) {
@@ -723,11 +722,10 @@ class DelegationBakerViewModel(application: Application) : AndroidViewModel(appl
 
         bakerDelegationData.submissionId = submissionId
 
-        try {
-            // If the status is received,
-            // the transaction has been at least accepted as valid.
-            App.appCore.getGrpcClient()
-                .getBlockItemStatus(Hash.from(submissionId))
+        val submissionStatus =try {
+            proxyRepository
+                .getSubmissionStatus(submissionId)
+                .status
         } catch (e: Exception) {
             Log.e("Error checking submission status", e)
             withContext(Dispatchers.Main) {
@@ -740,12 +738,14 @@ class DelegationBakerViewModel(application: Application) : AndroidViewModel(appl
         // Do not disable waiting state yet
         finishTransferCreation(
             submissionId = submissionId,
+            submissionStatus = submissionStatus,
             localTransactionType = localTransactionType,
         )
     }
 
     private suspend fun finishTransferCreation(
         submissionId: String,
+        submissionStatus: TransactionStatus,
         localTransactionType: TransactionType,
     ) = withContext(Dispatchers.Main) {
         val createdAt = Date().time
@@ -772,7 +772,7 @@ class DelegationBakerViewModel(application: Application) : AndroidViewModel(appl
             "",
             createdAt,
             submissionId,
-            TransactionStatus.UNKNOWN,
+            submissionStatus,
             TransactionOutcome.UNKNOWN,
             localTransactionType,
             //but amount is negative so it is listed as incoming positive

--- a/app/src/main/java/com/concordium/wallet/ui/connect/uni_ref/UniRefViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/connect/uni_ref/UniRefViewModel.kt
@@ -30,7 +30,7 @@ import com.concordium.wallet.data.model.GlobalParamsWrapper
 import com.concordium.wallet.data.model.SubmissionData
 import com.concordium.wallet.data.model.TransactionOutcome
 import com.concordium.wallet.data.model.TransactionType
-import com.concordium.wallet.data.model.TransferSubmissionStatus
+import com.concordium.wallet.data.model.SubmissionStatusResponse
 import com.concordium.wallet.data.model.WsMessageResponse
 import com.concordium.wallet.data.room.Account
 import com.concordium.wallet.data.room.Recipient
@@ -70,7 +70,7 @@ class UniRefViewModel(application: Application) : AndroidViewModel(application) 
         TransferRepository(App.appCore.session.walletStorage.database.transferDao())
 
     private var submitCredentialRequest: BackendRequest<SubmissionData>? = null
-    private var transferSubmissionStatusRequest: BackendRequest<TransferSubmissionStatus>? = null
+    private var transferSubmissionStatusRequest: BackendRequest<SubmissionStatusResponse>? = null
     private var globalParamsRequest: BackendRequest<GlobalParamsWrapper>? = null
     private var accountBalanceRequest: BackendRequest<AccountBalance>? = null
     private var recipientEncryptedKeyRequest: BackendRequest<AccountKeyData>? = null
@@ -119,7 +119,7 @@ class UniRefViewModel(application: Application) : AndroidViewModel(application) 
         var accountNonce: AccountNonce? = null
         var nrgCcdAmount: Long = 0
         var submissionId: String? = null
-        var transferSubmissionStatus: TransferSubmissionStatus? = null
+        var transferSubmissionStatus: SubmissionStatusResponse? = null
         var expiry: Long? = null
         var globalParams: GlobalParams? = null
         var createTransferOutput: CreateTransferOutput? = null
@@ -499,7 +499,7 @@ class UniRefViewModel(application: Application) : AndroidViewModel(application) 
     private fun submissionStatus(submissionId: String) {
         transferSubmissionStatusRequest?.dispose()
         transferSubmissionStatusRequest =
-            proxyRepository.getTransferSubmissionStatus(submissionId,
+            proxyRepository.getSubmissionStatus(submissionId,
                 {
                     tempData.transferSubmissionStatus = it
                     finishTransferCreation()

--- a/app/src/main/java/com/concordium/wallet/ui/transaction/transactiondetails/TransactionDetailsViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/transaction/transactiondetails/TransactionDetailsViewModel.kt
@@ -11,7 +11,7 @@ import com.concordium.wallet.data.backend.repository.ProxyRepository
 import com.concordium.wallet.data.model.Transaction
 import com.concordium.wallet.data.model.TransactionOutcome
 import com.concordium.wallet.data.model.TransactionSource
-import com.concordium.wallet.data.model.TransferSubmissionStatus
+import com.concordium.wallet.data.model.SubmissionStatusResponse
 import com.concordium.wallet.data.room.Account
 import com.concordium.wallet.ui.common.BackendErrorHandler
 
@@ -19,7 +19,7 @@ class TransactionDetailsViewModel(application: Application) : AndroidViewModel(a
 
     private val proxyRepository = ProxyRepository()
 
-    private var transferSubmissionStatusRequest: BackendRequest<TransferSubmissionStatus>? = null
+    private var transferSubmissionStatusRequest: BackendRequest<SubmissionStatusResponse>? = null
     lateinit var account: Account
     lateinit var transaction: Transaction
 
@@ -63,7 +63,7 @@ class TransactionDetailsViewModel(application: Application) : AndroidViewModel(a
     private fun loadTransferSubmissionStatus(submissionId: String) {
         _waitingLiveData.value = true
         transferSubmissionStatusRequest?.dispose()
-        transferSubmissionStatusRequest = proxyRepository.getTransferSubmissionStatus(submissionId,
+        transferSubmissionStatusRequest = proxyRepository.getSubmissionStatus(submissionId,
             {
                 // Update the transaction - the changes are not saved (they will be updated elsewhere)
                 transaction.transactionHash = it.transactionHash


### PR DESCRIPTION
## Purpose

Fix inability to submit SDK transactions via the public GRPC node when it is being spammed.

## Changes

- Add proxy endpoint to submit serialized transactions
- Submit baker/delegation transaction via the proxy
- Clean up submission status proxy endpoints
- Add deprecation warning (for visibility) to the GRPC client getter

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
