### PR TITLE
Reduce chain parameters reload

### DIFF
--- a/app/src/main/java/com/concordium/wallet/App.kt
+++ b/app/src/main/java/com/concordium/wallet/App.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import com.concordium.wallet.core.AppCore
 import com.concordium.wallet.core.notifications.AnnouncementNotificationManager
+import com.concordium.wallet.data.backend.price.tokenPriceModule
 import com.concordium.wallet.data.backend.ws.WsCreds
 import com.concordium.wallet.util.Log
 import com.reown.android.Core
@@ -12,6 +13,9 @@ import com.reown.android.relay.ConnectionType
 import com.reown.android.relay.NetworkClientTimeout
 import com.reown.sign.client.Sign
 import com.reown.sign.client.SignClient
+import org.koin.android.ext.koin.androidContext
+import org.koin.android.ext.koin.androidLogger
+import org.koin.core.context.GlobalContext.startKoin
 import java.util.concurrent.TimeUnit
 
 class App : Application() {
@@ -33,6 +37,16 @@ class App : Application() {
 
     private fun initialize() {
         appContext = this
+
+        startKoin {
+            androidLogger()
+            androidContext(this@App)
+
+            modules(
+                tokenPriceModule,
+            )
+        }
+
         initAppCore()
         initWalletConnect()
         appCore.tracker.installation(this)

--- a/app/src/main/java/com/concordium/wallet/data/backend/ProxyBackend.kt
+++ b/app/src/main/java/com/concordium/wallet/data/backend/ProxyBackend.kt
@@ -76,10 +76,7 @@ interface ProxyBackend {
     ): Call<TransactionCost>
 
     @GET("v0/chainParameters")
-    fun chainParameters(): Call<ChainParameters>
-
-    @GET("v0/chainParameters")
-    suspend fun chainParametersSuspended(): Response<ChainParameters>
+    suspend fun chainParameters(): ChainParameters
 
     @GET("v0/passiveDelegation")
     suspend fun passiveDelegationSuspended(): Response<PassiveDelegation>

--- a/app/src/main/java/com/concordium/wallet/data/backend/price/TokenPriceModule.kt
+++ b/app/src/main/java/com/concordium/wallet/data/backend/price/TokenPriceModule.kt
@@ -1,0 +1,12 @@
+package com.concordium.wallet.data.backend.price
+
+import com.concordium.wallet.data.backend.repository.ProxyRepository
+import org.koin.dsl.module
+
+val tokenPriceModule = module {
+    single {
+        TokenPriceRepository(
+            proxyRepository = ProxyRepository(),
+        )
+    }
+}

--- a/app/src/main/java/com/concordium/wallet/data/backend/price/TokenPriceRepository.kt
+++ b/app/src/main/java/com/concordium/wallet/data/backend/price/TokenPriceRepository.kt
@@ -1,0 +1,43 @@
+package com.concordium.wallet.data.backend.price
+
+import com.concordium.wallet.data.backend.repository.ProxyRepository
+import com.concordium.wallet.data.model.SimpleFraction
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+class TokenPriceRepository(
+    private val proxyRepository: ProxyRepository,
+) {
+
+    private var cachedEurPerMicroCcd: Pair<SimpleFraction, Long>? = null
+    private val eurPerMicroCcdMutex = Mutex()
+
+    suspend fun getEurPerMicroCcd(): Result<SimpleFraction> = eurPerMicroCcdMutex.withLock {
+        runCatching {
+            cachedEurPerMicroCcd
+                ?.takeIf { System.currentTimeMillis() - it.second < CACHE_TTL_MS }
+                ?.first
+                ?: getFreshEurPerMicroCcd().also {
+                    synchronized(this@TokenPriceRepository) {
+                        cachedEurPerMicroCcd = it to System.currentTimeMillis()
+                    }
+                }
+        }
+    }
+
+    private suspend fun getFreshEurPerMicroCcd(): SimpleFraction =
+        proxyRepository
+            .getChainParameters()
+            .microGtuPerEuro
+            .let { microGtuPerEuro ->
+                // Reverse the fraction.
+                SimpleFraction(
+                    numerator = microGtuPerEuro.denominator,
+                    denominator = microGtuPerEuro.numerator,
+                )
+            }
+
+    private companion object {
+        private const val CACHE_TTL_MS = 60 * 60 * 1000
+    }
+}

--- a/app/src/main/java/com/concordium/wallet/data/backend/repository/ProxyRepository.kt
+++ b/app/src/main/java/com/concordium/wallet/data/backend/repository/ProxyRepository.kt
@@ -13,7 +13,6 @@ import com.concordium.wallet.data.model.BakerPoolStatus
 import com.concordium.wallet.data.model.CIS2Tokens
 import com.concordium.wallet.data.model.CIS2TokensBalances
 import com.concordium.wallet.data.model.CIS2TokensMetadata
-import com.concordium.wallet.data.model.ChainParameters
 import com.concordium.wallet.data.model.CredentialWrapper
 import com.concordium.wallet.data.model.GlobalParamsWrapper
 import com.concordium.wallet.data.model.SubmissionData
@@ -228,28 +227,7 @@ class ProxyRepository {
         )
     }
 
-    fun getChainParameters(
-        success: (ChainParameters) -> Unit,
-        failure: ((Throwable) -> Unit)?,
-    ): BackendRequest<ChainParameters> {
-        val call = backend.chainParameters()
-        call.enqueue(object : BackendCallback<ChainParameters>() {
-            override fun onResponseData(response: ChainParameters) {
-                success(response)
-            }
-
-            override fun onFailure(t: Throwable) {
-                failure?.invoke(t)
-            }
-        })
-        return BackendRequest(
-            call = call,
-            success = success,
-            failure = failure
-        )
-    }
-
-    suspend fun getChainParametersSuspended() = backend.chainParametersSuspended()
+    suspend fun getChainParameters() = backend.chainParameters()
 
     suspend fun getPassiveDelegationSuspended() = backend.passiveDelegationSuspended()
 

--- a/app/src/main/java/com/concordium/wallet/data/model/Token.kt
+++ b/app/src/main/java/com/concordium/wallet/data/model/Token.kt
@@ -29,8 +29,10 @@ data class Token(
     var isSelected: Boolean = false,
     var isNewlyReceived: Boolean = false,
     var isEarning: Boolean = false,
-    var denominator: BigInteger = BigInteger.ZERO,
-    var numerator: BigInteger = BigInteger.ZERO
+    /**
+     * Number of EUR per smallest token unit.
+     */
+    val eurPerUnit: SimpleFraction? = null,
 ) : Serializable {
 
     val symbol: String
@@ -51,7 +53,7 @@ data class Token(
     constructor(
         contractToken: ContractToken,
         isSelected: Boolean = false,
-        isEarning: Boolean = false
+        isEarning: Boolean = false,
     ) : this(
         uid = contractToken.id.toString(),
         token = contractToken.token,
@@ -70,8 +72,7 @@ data class Token(
          */
         fun ccd(
             account: Account,
-            denominator: BigInteger = BigInteger.ZERO,
-            numerator: BigInteger = BigInteger.ZERO
+            eurPerMicroCcd: SimpleFraction? = null,
         ) = Token(
             uid = "CCD",
             metadata = TokenMetadata(
@@ -85,8 +86,7 @@ data class Token(
             ),
             balance = account.balance,
             isEarning = account.isBaking() || account.isDelegating(),
-            denominator = denominator,
-            numerator = numerator
+            eurPerUnit = eurPerMicroCcd,
         )
     }
 }

--- a/app/src/main/java/com/concordium/wallet/data/util/CurrencyUtil.kt
+++ b/app/src/main/java/com/concordium/wallet/data/util/CurrencyUtil.kt
@@ -1,5 +1,6 @@
 package com.concordium.wallet.data.util
 
+import com.concordium.wallet.data.model.SimpleFraction
 import com.concordium.wallet.data.model.Token
 import com.concordium.wallet.util.toBigInteger
 import java.math.BigDecimal
@@ -37,7 +38,7 @@ object CurrencyUtil {
     fun formatGTU(
         value: BigInteger,
         decimals: Int = 6,
-        withCommas: Boolean = true
+        withCommas: Boolean = true,
     ): String {
         if (value == BigInteger.ZERO) return ZERO_AMOUNT
         if (decimals <= 0) return value.toString()
@@ -122,15 +123,15 @@ object CurrencyUtil {
         return noDecimalSeparatorString.toBigInteger()
     }
 
-    fun toEURRate(amount: BigInteger, denominator: BigInteger, numerator: BigInteger): String {
+    fun toEURRate(amount: BigInteger, eurPerUnit: SimpleFraction): String {
         val amountBigDecimal = BigDecimal(amount)
-        val denominatorBigDecimal = BigDecimal(denominator)
-        val numeratorBigDecimal = BigDecimal(numerator)
+        val denominatorBigDecimal = BigDecimal(eurPerUnit.denominator)
+        val numeratorBigDecimal = BigDecimal(eurPerUnit.numerator)
 
-        return if (numeratorBigDecimal > BigDecimal.ZERO)
-            amountBigDecimal.multiply(denominatorBigDecimal)
-            .divide(numeratorBigDecimal, 2, RoundingMode.HALF_UP).toString()
-        else "0"
+        return amountBigDecimal
+            .multiply(numeratorBigDecimal)
+            .divide(denominatorBigDecimal, 2, RoundingMode.HALF_UP)
+            .toString()
     }
 
     private fun checkGTUString(stringValue: String): Boolean {

--- a/app/src/main/java/com/concordium/wallet/ui/account/accountdetails/AccountDetailsFragment.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/account/accountdetails/AccountDetailsFragment.kt
@@ -575,7 +575,7 @@ class AccountDetailsFragment : BaseFragment(), EarnDelegate by EarnDelegateImpl(
         intent.putExtra(SendTokenActivity.ACCOUNT, viewModelAccountDetails.account)
         intent.putExtra(
             SendTokenActivity.TOKEN,
-            Token.ccd(viewModelAccountDetails.account, BigInteger.ZERO, BigInteger.ZERO)
+            Token.ccd(viewModelAccountDetails.account)
         )
         intent.putExtra(SendTokenActivity.PARENT_ACTIVITY, this::class.java.canonicalName)
 

--- a/app/src/main/java/com/concordium/wallet/ui/account/earn/EarnViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/account/earn/EarnViewModel.kt
@@ -3,11 +3,13 @@ package com.concordium.wallet.ui.account.earn
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
 import com.concordium.wallet.core.arch.Event
 import com.concordium.wallet.data.backend.repository.ProxyRepository
 import com.concordium.wallet.data.model.ChainParameters
 import com.concordium.wallet.ui.common.BackendErrorHandler
 import com.concordium.wallet.util.Log
+import kotlinx.coroutines.launch
 
 class EarnViewModel(application: Application) : AndroidViewModel(application) {
     private val proxyRepository = ProxyRepository()
@@ -15,15 +17,12 @@ class EarnViewModel(application: Application) : AndroidViewModel(application) {
     val chainParameters: MutableLiveData<ChainParameters> by lazy { MutableLiveData<ChainParameters>() }
     val error: MutableLiveData<Event<Int>> by lazy { MutableLiveData<Event<Int>>() }
 
-    fun loadChainParameters() {
-        proxyRepository.getChainParameters(
-            {
-                chainParameters.value = it
-            },
-            {
-                handleBackendError(it)
-            }
-        )
+    fun loadChainParameters() = viewModelScope.launch {
+        try {
+            chainParameters.value = proxyRepository.getChainParameters()
+        } catch (e: Exception) {
+            handleBackendError(e)
+        }
     }
 
     private fun handleBackendError(throwable: Throwable) {

--- a/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/common/DelegationBakerViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/bakerdelegation/common/DelegationBakerViewModel.kt
@@ -399,17 +399,14 @@ class DelegationBakerViewModel(application: Application) : AndroidViewModel(appl
         )
     }
 
-    fun loadChainParameters() {
-        proxyRepository.getChainParameters(
-            {
-                bakerDelegationData.chainParameters = it
-                _chainParametersLoadedLiveData.value = true
-            },
-            {
-                _chainParametersLoadedLiveData.value = false
-                handleBackendError(it)
-            }
-        )
+    fun loadChainParameters() = viewModelScope.launch {
+        try {
+            bakerDelegationData.chainParameters = proxyRepository.getChainParameters()
+            _chainParametersLoadedLiveData.value = true
+        } catch (e: Exception){
+            _chainParametersLoadedLiveData.value = false
+            handleBackendError(e)
+        }
     }
 
     fun loadChainParametersPassiveDelegationAndPossibleBakerPool() {
@@ -427,14 +424,10 @@ class DelegationBakerViewModel(application: Application) : AndroidViewModel(appl
                     }
                 },
                 async(Dispatchers.IO) {
-                    val response = proxyRepository.getChainParametersSuspended()
-                    if (response.isSuccessful) {
-                        response.body()?.let {
-                            bakerDelegationData.chainParameters = it
-                        }
-                    } else {
-                        val error = ErrorParser.parseError(response)
-                        _errorLiveData.value = error?.let { Event(it.error) }
+                    try {
+                        bakerDelegationData.chainParameters=proxyRepository.getChainParameters()
+                    } catch (e: Exception){
+                        handleBackendError(e)
                     }
                 }
             )

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/TokensAccountDetailsAdapter.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/TokensAccountDetailsAdapter.kt
@@ -17,7 +17,7 @@ import java.math.BigInteger
 
 class TokensAccountDetailsAdapter(
     private val context: Context,
-    private val showManageButton: Boolean
+    private val showManageButton: Boolean,
 ) : RecyclerView.Adapter<TokensAccountDetailsAdapter.ViewHolder>() {
     private var tokenClickListener: TokenClickListener? = null
     private var addButtonClickListener: () -> Unit = {}
@@ -103,14 +103,22 @@ class TokensAccountDetailsAdapter(
                 .into(holder.binding.tokenIcon)
 
             holder.binding.eurRate.visibility = View.VISIBLE
-            holder.binding.eurRate.text = if (showManageButton)
-                context.getString(
-                    R.string.cis_eur_rate,
-                    CurrencyUtil.toEURRate(token.balance, token.denominator, token.numerator)
-                )
-            else
-                context.getString(R.string.cis_at_disposal)
-
+            holder.binding.eurRate.text =
+                if (showManageButton) {
+                    if (token.eurPerUnit != null) {
+                        context.getString(
+                            R.string.cis_eur_rate,
+                            CurrencyUtil.toEURRate(
+                                token.balance,
+                                token.eurPerUnit
+                            )
+                        )
+                    } else {
+                        ""
+                    }
+                } else {
+                    context.getString(R.string.cis_at_disposal)
+                }
         } else {
             Glide.with(context)
                 .load(R.drawable.ic_token_no_image)

--- a/app/src/main/java/com/concordium/wallet/ui/walletconnect/WalletConnectSignTransactionRequestHandler.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/walletconnect/WalletConnectSignTransactionRequestHandler.kt
@@ -10,7 +10,6 @@ import com.concordium.wallet.data.cryptolib.CreateTransferOutput
 import com.concordium.wallet.data.cryptolib.ParameterToJsonInput
 import com.concordium.wallet.data.model.AccountData
 import com.concordium.wallet.data.model.AccountNonce
-import com.concordium.wallet.data.model.ChainParameters
 import com.concordium.wallet.data.model.TransactionCost
 import com.concordium.wallet.data.model.TransactionType
 import com.concordium.wallet.data.room.Account
@@ -204,10 +203,7 @@ class WalletConnectSignTransactionRequestHandler(
                 getSimpleTransferCost()
 
             is AccountTransactionPayload.Update -> {
-                val chainParameters: ChainParameters =
-                    checkNotNull(proxyRepository.getChainParametersSuspended().body()) {
-                        "Failed loading chain parameters"
-                    }
+                val chainParameters = proxyRepository.getChainParameters()
 
                 val maxEnergy: Long =
                     if (transactionPayload.maxEnergy != null) {


### PR DESCRIPTION
## Purpose

Do not load chain params 5-6 times on account details screen update.

## Changes

- Added `TokenPriceRepository` to load and cache CCD:EUR price. The price is cached in memory for 1 hour
- Unified `ProxyRepository` chain parameters getter – only suspended version left
- `TokenPriceRepository` is being injected where needed with Koin (there already was unconfigured Koin in the app)
- Therefore `chainParameters` request for fetching CCD:EUR price gets executed once per hour, on demand
- `numerator` and `denominator` in `Token` replaced with optional `eurPerUnit: SimpleFraction?`
- `CurrencyUtil.toEURRate()` now accepts `SimpleFraction` as price per unit
- `0 EUR` is no longer shown if the price can't be loaded

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
