### PR TITLE
WAL-1025 Remove list of exchanges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- On the Buy screen, exchange sections are replaced with an external link
+
 ## [1.9.1] - 2025-06-04
 
 ### Fixed

--- a/app/src/main/java/com/concordium/wallet/ui/onramp/CcdOnrampItemAdapter.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/onramp/CcdOnrampItemAdapter.kt
@@ -1,9 +1,13 @@
 package com.concordium.wallet.ui.onramp
 
 import android.annotation.SuppressLint
+import android.content.Intent
+import android.net.Uri
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
@@ -11,6 +15,7 @@ import com.concordium.wallet.R
 import com.concordium.wallet.databinding.ListItemCcdOnrampHeaderBinding
 import com.concordium.wallet.databinding.ListItemCcdOnrampSectionBinding
 import com.concordium.wallet.databinding.ListItemCcdOnrampSiteBinding
+import com.concordium.wallet.uicore.handleUrlClicks
 
 class CcdOnrampItemAdapter(
     private val onReadDisclaimerClicked: () -> Unit,
@@ -30,6 +35,9 @@ class CcdOnrampItemAdapter(
 
         CcdOnrampListItem.NoneAvailable ->
             R.layout.list_item_ccd_onramp_none_available
+
+        CcdOnrampListItem.ExchangesNotice ->
+            R.layout.list_item_ccd_onramp_exchanges_notice
 
         CcdOnrampListItem.Disclaimer ->
             R.layout.list_item_ccd_onramp_disclaimer
@@ -51,6 +59,9 @@ class CcdOnrampItemAdapter(
 
             R.layout.list_item_ccd_onramp_none_available ->
                 ViewHolder.NoneAvailable(view)
+
+            R.layout.list_item_ccd_onramp_exchanges_notice ->
+                ViewHolder.ExchangesNotice(view)
 
             R.layout.list_item_ccd_onramp_disclaimer ->
                 ViewHolder.Disclaimer(view)
@@ -97,9 +108,11 @@ class CcdOnrampItemAdapter(
                 }
             }
 
-            is ViewHolder.NoneAvailable -> {}
-
-            is ViewHolder.Disclaimer -> {}
+            is ViewHolder.NoneAvailable,
+            is ViewHolder.ExchangesNotice,
+            is ViewHolder.Disclaimer,
+            -> {
+            }
         }
     }
 
@@ -123,6 +136,15 @@ class CcdOnrampItemAdapter(
         }
 
         class NoneAvailable(itemView: View) : ViewHolder(itemView)
+
+        class ExchangesNotice(itemView: View) : ViewHolder(itemView) {
+            init {
+                (itemView as TextView).handleUrlClicks { url ->
+                    val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                    ContextCompat.startActivity(itemView.context, browserIntent, null)
+                }
+            }
+        }
 
         class Disclaimer(itemView: View) : ViewHolder(itemView)
     }

--- a/app/src/main/java/com/concordium/wallet/ui/onramp/CcdOnrampListItem.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/onramp/CcdOnrampListItem.kt
@@ -45,5 +45,7 @@ sealed interface CcdOnrampListItem {
 
     object NoneAvailable : CcdOnrampListItem
 
+    object ExchangesNotice: CcdOnrampListItem
+
     object Disclaimer : CcdOnrampListItem
 }

--- a/app/src/main/java/com/concordium/wallet/ui/onramp/CcdOnrampListItem.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/onramp/CcdOnrampListItem.kt
@@ -14,12 +14,6 @@ sealed interface CcdOnrampListItem {
             nameRes = when (siteType) {
                 CcdOnrampSite.Type.PAYMENT_GATEWAY ->
                     R.string.ccd_onramp_site_type_payment_gateway
-
-                CcdOnrampSite.Type.CEX ->
-                    R.string.ccd_onramp_site_type_cex
-
-                CcdOnrampSite.Type.DEX ->
-                    R.string.ccd_onramp_site_type_dex
             }
         )
     }

--- a/app/src/main/java/com/concordium/wallet/ui/onramp/CcdOnrampSite.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/onramp/CcdOnrampSite.kt
@@ -11,8 +11,6 @@ data class CcdOnrampSite(
 ): Serializable {
     enum class Type {
         PAYMENT_GATEWAY,
-        CEX,
-        DEX
         ;
     }
 }

--- a/app/src/main/java/com/concordium/wallet/ui/onramp/CcdOnrampSiteRepository.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/onramp/CcdOnrampSiteRepository.kt
@@ -18,60 +18,6 @@ class CcdOnrampSiteRepository {
             type = CcdOnrampSite.Type.PAYMENT_GATEWAY,
             acceptsCreditCard = true,
         ),
-        CcdOnrampSite(
-            name = "LetsExchange",
-            url = "https://letsexchange.io/",
-            logoUrl = "https://assets-global.website-files.com/64f060f3fc95f9d2081781db/64fed810c7dd2cfc068c17cf_1680692222678%20(1).jpg",
-            type = CcdOnrampSite.Type.CEX,
-        ),
-        CcdOnrampSite(
-            name = "KuCoin",
-            url = "https://www.kucoin.com/",
-            logoUrl = "https://assets-global.website-files.com/64f060f3fc95f9d2081781db/64f0d1d17b59787f0d1b3740_logo-favicon-kucoin.png",
-            type = CcdOnrampSite.Type.CEX,
-        ),
-        CcdOnrampSite(
-            name = "Bitfinex",
-            url = "https://trading.bitfinex.com/t/CCD:USD?type=exchange",
-            logoUrl = "https://assets-global.website-files.com/64f060f3fc95f9d2081781db/64f0d15bd065ec0e03a32ac5_bitfinex.png",
-            type = CcdOnrampSite.Type.CEX,
-        ),
-        CcdOnrampSite(
-            name = "AscendEX (BitMax)",
-            url = "https://ascendex.com/en/cashtrade-spottrading/usdt/ccd",
-            logoUrl = "https://assets-global.website-files.com/64f060f3fc95f9d2081781db/64f0d273cc264cf97db45e72_logo-favicon-ascendex.png",
-            type = CcdOnrampSite.Type.CEX,
-        ),
-        CcdOnrampSite(
-            name = "MEXC",
-            url = "https://www.mexc.com/",
-            logoUrl = "https://assets-global.website-files.com/64f060f3fc95f9d2081781db/64f0d2446607fca14ba4af27_logo-favicon-mexc.png",
-            type = CcdOnrampSite.Type.CEX,
-        ),
-        CcdOnrampSite(
-            name = "Bit2Me",
-            url = "https://bit2me.com/price/concordium",
-            logoUrl = "https://assets-global.website-files.com/64f060f3fc95f9d2081781db/64f0d2d9a6d5f9d1cca6dfe6_logo-favicon-bit2me.png",
-            type = CcdOnrampSite.Type.CEX,
-        ),
-        CcdOnrampSite(
-            name = "LCX",
-            url = "https://exchange.lcx.com/",
-            logoUrl = "https://assets-global.website-files.com/64f060f3fc95f9d2081781db/660ef2975d8736c5529f54b9_LCX.jpg",
-            type = CcdOnrampSite.Type.CEX,
-        ),
-        CcdOnrampSite(
-            name = "Gate.io",
-            url = "https://www.gate.io/trade/CCD_USDT",
-            logoUrl = "https://cdn.prod.website-files.com/64f060f3fc95f9d2081781db/668529303de2213473aa1be0_1654851660739235057_downlod_gate1.svg",
-            type = CcdOnrampSite.Type.CEX,
-        ),
-        CcdOnrampSite(
-            name = "Concordex",
-            url = "https://app.concordex.io/trade?mode=simple",
-            logoUrl = "https://cdn.prod.website-files.com/64f060f3fc95f9d2081781db/64f0d420d065ec0e03a694b9_logo-favicon-concordex.png",
-            type = CcdOnrampSite.Type.DEX,
-        ),
     )
 
     private val testnetSites = listOf(
@@ -81,16 +27,7 @@ class CcdOnrampSiteRepository {
             logoUrl = "https://em-content.zobj.net/source/apple/391/smiling-face-with-sunglasses_1f60e.png",
             type = CcdOnrampSite.Type.PAYMENT_GATEWAY,
         ),
-        CcdOnrampSite(
-            name = "Concordex Testnet",
-            url = "https://testnet.concordex.io/trade?mode=simple",
-            logoUrl = "https://cdn.prod.website-files.com/64f060f3fc95f9d2081781db/64f0d420d065ec0e03a694b9_logo-favicon-concordex.png",
-            type = CcdOnrampSite.Type.DEX,
-        )
     )
-
-    val hasSites: Boolean
-        get() = getSites().isNotEmpty()
 
     fun getSites(): List<CcdOnrampSite> =
         when {

--- a/app/src/main/java/com/concordium/wallet/ui/onramp/CcdOnrampSitesViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/onramp/CcdOnrampSitesViewModel.kt
@@ -103,6 +103,7 @@ class CcdOnrampSitesViewModel(application: Application) : AndroidViewModel(appli
             items.add(CcdOnrampListItem.NoneAvailable)
         }
 
+        items.add(CcdOnrampListItem.ExchangesNotice)
         items.add(CcdOnrampListItem.Disclaimer)
 
         _listItemsLiveData.postValue(items)

--- a/app/src/main/java/com/concordium/wallet/ui/onramp/CcdOnrampSitesViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/onramp/CcdOnrampSitesViewModel.kt
@@ -74,8 +74,6 @@ class CcdOnrampSitesViewModel(application: Application) : AndroidViewModel(appli
                 )
             )
 
-            site.type == CcdOnrampSite.Type.DEX -> _siteToOpen.emit(Pair(site, false))
-
             else -> _siteToOpen.emit(Pair(site, true))
         }
     }

--- a/app/src/main/res/layout/list_item_ccd_onramp_disclaimer.xml
+++ b/app/src/main/res/layout/list_item_ccd_onramp_disclaimer.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginTop="64dp"
+    android:layout_marginTop="40dp"
     android:orientation="vertical"
     android:paddingBottom="36dp">
 

--- a/app/src/main/res/layout/list_item_ccd_onramp_disclaimer.xml
+++ b/app/src/main/res/layout/list_item_ccd_onramp_disclaimer.xml
@@ -19,7 +19,6 @@
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="36dp"
         android:layout_marginTop="8dp"
-        android:gravity="center"
         android:text="@string/ccd_onramp_disclaimer_content"
         android:textAppearance="@style/CCX_Typography_Body"
         android:textColor="@color/ccx_neutral_tint_2" />

--- a/app/src/main/res/layout/list_item_ccd_onramp_exchanges_notice.xml
+++ b/app/src/main/res/layout/list_item_ccd_onramp_exchanges_notice.xml
@@ -2,9 +2,9 @@
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginHorizontal="32dp"
+    android:layout_marginTop="40dp"
     android:gravity="center"
-    android:paddingVertical="40dp"
-    android:text="@string/ccd_onramp_none_available"
+    android:text="@string/ccd_onramp_exchanges_notice"
     android:textAppearance="@style/CCX_Typography_Body"
-    android:textColor="@color/ccx_neutral_tint_3" />
+    android:textColor="@color/ccx_neutral_tint_2"
+    android:textColorLink="@color/ccx_neutral_tint_2" />

--- a/app/src/main/res/layout/list_item_ccd_onramp_header.xml
+++ b/app/src/main/res/layout/list_item_ccd_onramp_header.xml
@@ -3,12 +3,12 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:paddingBottom="18dp">
+    android:paddingBottom="16dp">
 
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
+        android:layout_marginTop="14dp"
         android:gravity="center"
         android:text="@string/ccd_onramp_subtitle"
         android:textAppearance="@style/CCX_Typography_Body"

--- a/app/src/main/res/layout/list_item_ccd_onramp_section.xml
+++ b/app/src/main/res/layout/list_item_ccd_onramp_section.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingTop="42dp"
+    android:paddingTop="24dp"
     android:paddingBottom="16dp"
     android:textAppearance="@style/CCX_Typography_Caption"
     android:textColor="@color/cryptox_black_additional"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1275,10 +1275,10 @@
     <string name="ccd_onramp_disclaimer_content">
         The information regarding the CCD on any Concordium website does not constitute an offer or solicitation to purchase CCDs.
         The information on the CCD on this website is only directed to persons in countries other than the United States.
-        \n\n
-        Without limiting the foregoing, in no event would any offering of CCD by Concordium be intended to be available to residents of the United States.
-        \n\n
-        By clicking on any of the above links, you may be getting access to various services, including trading services.
+        \n\nWithout
+        limiting the foregoing, in no event would any offering of CCD by Concordium be intended to be available to residents of the United States.
+        \n\nBy
+        clicking on any of the above links, you may be getting access to various services, including trading services.
         These services are offered by third parties and the use of such services are subject to terms of conditions
         defined by such third parties and Concordium is not responsible for and does not assume any liabilities
         in relation to the use of such services.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1266,8 +1266,6 @@
     <string name="ccd_onramp_subtitle">CCD is listed in the following external exchanges and services. Some of these venues will guide you through their onboarding process and wallet choices.</string>
     <string name="ccd_onramp_read_disclaimer"><u>Read our disclaimer for more.</u></string>
     <string name="ccd_onramp_site_type_payment_gateway">Payment Gateway</string>
-    <string name="ccd_onramp_site_type_cex">CEX</string>
-    <string name="ccd_onramp_site_type_dex">DEX</string>
     <string name="ccd_onramp_exchanges_notice">
         List of supported exchanges can be found at <a href="https://concordium.com/ccd-wallet">concordium.com/ccd-wallet</a>
     </string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1268,6 +1268,9 @@
     <string name="ccd_onramp_site_type_payment_gateway">Payment Gateway</string>
     <string name="ccd_onramp_site_type_cex">CEX</string>
     <string name="ccd_onramp_site_type_dex">DEX</string>
+    <string name="ccd_onramp_exchanges_notice">
+        List of supported exchanges can be found at <a href="https://concordium.com/ccd-wallet">concordium.com/ccd-wallet</a>
+    </string>
     <string name="ccd_onramp_disclaimer_title">Disclaimer</string>
     <string name="ccd_onramp_disclaimer_content">
         The information regarding the CCD on any Concordium website does not constitute an offer or solicitation to purchase CCDs.


### PR DESCRIPTION
## Purpose

To streamline the UI/UX on both platforms, we need to remove the list of currently supported exchanges within the CryptoX

Instead, we would show a message linking users to our website: “List of supported exchanges can be found at concordium.com/ccd-wallet

## Changes

- On the Buy screen, exchange sections are replaced with an external link
- Reduced vertical paddings on the screen
- Fixed the disclaimer text alignment 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
