### PR TITLE
Remove EUROe token from defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - On the Buy screen, exchange sections are replaced with an external link
 
+### Removed
+
+- EUROe token from the default token set
+
 ## [1.9.1] - 2025-06-04
 
 ### Fixed

--- a/app/src/main/java/com/concordium/wallet/ui/cis2/defaults/DefaultTokensManagerFactory.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/cis2/defaults/DefaultTokensManagerFactory.kt
@@ -8,16 +8,6 @@ class DefaultTokensManagerFactory(
 ) {
     private val testnetDefaultFungibleTokens: List<DefaultFungibleToken> = listOf(
         DefaultFungibleToken(
-            symbol = "EUROe",
-            name = "EUROe Stablecoin",
-            contractIndex = "7260",
-            contractName = "euroe_stablecoin_v3",
-            description = "EUROe is a modern European stablecoin - a digital representation of fiat Euros",
-            thumbnailUrl = "https://dev.euroe.com/persistent/token-icon/png/128x128.png",
-            decimals = 6,
-            token = "",
-        ),
-        DefaultFungibleToken(
             symbol = "wCCD",
             name = "Wrapped CCD Token",
             contractIndex = "2059",
@@ -30,16 +20,6 @@ class DefaultTokensManagerFactory(
     )
 
     private val mainnetDefaultFungibleTokens: List<DefaultFungibleToken> = listOf(
-        DefaultFungibleToken(
-            symbol = "EUROe",
-            name = "EUROe Stablecoin",
-            contractIndex = "9390",
-            contractName = "euroe_stablecoin",
-            description = "EUROe is a modern European stablecoin - a digital representation of fiat Euros",
-            thumbnailUrl = "https://dev.euroe.com/persistent/token-icon/png/128x128.png",
-            decimals = 6,
-            token = "",
-        ),
         DefaultFungibleToken(
             symbol = "wCCD",
             name = "Wrapped CCD Token",


### PR DESCRIPTION
## Purpose

Remove EUROe token from defaults

## Changes 

- EUROe is no longer added to the default token list for new accounts
- If you currently have EUROe in your wallet/account - it will stay visible

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
