### PR TITLE
Approve WC session specifying the chain

### DIFF
--- a/app/src/main/java/com/concordium/wallet/ui/walletconnect/WalletConnectViewModel.kt
+++ b/app/src/main/java/com/concordium/wallet/ui/walletconnect/WalletConnectViewModel.kt
@@ -415,6 +415,7 @@ private constructor(
                 proposerPublicKey = sessionProposalPublicKey,
                 namespaces = mapOf(
                     sessionProposalNamespaceKey to Sign.Model.Namespace.Session(
+                        chains = listOf(sessionProposalNamespaceChain),
                         accounts = listOf("$sessionProposalNamespaceChain:$accountAddress"),
                         methods = sessionProposalNamespace.methods,
                         events = sessionProposalNamespace.events,


### PR DESCRIPTION
Prevent theoretical situation when the wallet accepts a session for many chains, while in fact it supports only one of them.