### PR TITLE
Fix not showing tokens after switching wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Not showing tokens after switching wallets
+
 ## [1.13.1] - 2025-09-22
 
 ### Changed

--- a/app/src/main/java/com/concordium/wallet/core/tokens/TokensInteractor.kt
+++ b/app/src/main/java/com/concordium/wallet/core/tokens/TokensInteractor.kt
@@ -1,5 +1,6 @@
 package com.concordium.wallet.core.tokens
 
+import com.concordium.wallet.App
 import com.concordium.wallet.data.AccountRepository
 import com.concordium.wallet.data.ContractTokensRepository
 import com.concordium.wallet.data.PLTRepository
@@ -18,9 +19,6 @@ import com.concordium.wallet.util.Log
 
 class TokensInteractor(
     private val proxyRepository: ProxyRepository,
-    private val contractTokensRepository: ContractTokensRepository,
-    private val pltRepository: PLTRepository,
-    private val accountRepository: AccountRepository,
     private val tokenPriceRepository: TokenPriceRepository,
     private val loadTokensBalancesUseCase: LoadTokensBalancesUseCase,
     private val loadCIS2TokensUseCase: LoadCIS2TokensUseCase,
@@ -32,14 +30,23 @@ class TokensInteractor(
         loadBalances: Boolean = true,
         onlyTransferable: Boolean = false,
         addCCDToken: Boolean = true,
-        ccdWithTotalBalance: Boolean = false
+        ccdWithTotalBalance: Boolean = false,
     ): Result<List<Token>> = runCatching {
+
+        val contractTokensRepository = ContractTokensRepository(
+            App.appCore.session.walletStorage.database.contractTokenDao()
+        )
+
         val ccdToken = getCCDDefaultToken(accountAddress, ccdWithTotalBalance)
 
         val contractTokens =
             contractTokensRepository
                 .getTokens(accountAddress)
                 .map(ContractTokenEntity::toContractToken)
+
+        val pltRepository = PLTRepository(
+            App.appCore.session.walletStorage.database.protocolLevelTokenDao()
+        )
 
         val pltTokens =
             pltRepository
@@ -139,6 +146,9 @@ class TokensInteractor(
     ): Result<Boolean> {
         return when (token) {
             is ContractToken -> {
+                val contractTokensRepository = ContractTokensRepository(
+                    App.appCore.session.walletStorage.database.contractTokenDao()
+                )
                 contractTokensRepository.delete(
                     accountAddress = accountAddress,
                     contractIndex = token.contractIndex,
@@ -148,6 +158,9 @@ class TokensInteractor(
             }
 
             is ProtocolLevelToken -> {
+                val pltRepository = PLTRepository(
+                    App.appCore.session.walletStorage.database.protocolLevelTokenDao()
+                )
                 pltRepository.hideToken(accountAddress, token.tokenId)
                 Result.success(true)
             }
@@ -158,20 +171,37 @@ class TokensInteractor(
 
     suspend fun unmarkNewlyReceivedToken(token: Token) {
         when (token) {
-            is ContractToken -> contractTokensRepository.unmarkNewlyReceived(token.token)
-            is ProtocolLevelToken -> pltRepository.unmarkNewlyReceived(token.tokenId)
+            is ContractToken -> {
+                val contractTokensRepository = ContractTokensRepository(
+                    App.appCore.session.walletStorage.database.contractTokenDao()
+                )
+                contractTokensRepository.unmarkNewlyReceived(token.token)
+            }
+
+            is ProtocolLevelToken -> {
+                val pltRepository = PLTRepository(
+                    App.appCore.session.walletStorage.database.protocolLevelTokenDao()
+                )
+                pltRepository.unmarkNewlyReceived(token.tokenId)
+            }
+
             else -> throw UnsupportedOperationException("Cannot unmark CCD token")
         }
     }
 
     private suspend fun getCCDDefaultToken(
         accountAddress: String,
-        withTotalBalance: Boolean = false
-    ) = CCDToken(
-        account = accountRepository.findByAddress(accountAddress)
-            ?: error("Account $accountAddress not found"),
-        withTotalBalance = withTotalBalance,
-        eurPerMicroCcd = tokenPriceRepository.getEurPerMicroCcd()
-            .getOrNull()
-    )
+        withTotalBalance: Boolean = false,
+    ): CCDToken {
+        val accountRepository = AccountRepository(
+            App.appCore.session.walletStorage.database.accountDao()
+        )
+        return CCDToken(
+            account = accountRepository.findByAddress(accountAddress)
+                ?: error("Account $accountAddress not found"),
+            withTotalBalance = withTotalBalance,
+            eurPerMicroCcd = tokenPriceRepository.getEurPerMicroCcd()
+                .getOrNull()
+        )
+    }
 }

--- a/app/src/main/java/com/concordium/wallet/core/tokens/TokensInteractorModule.kt
+++ b/app/src/main/java/com/concordium/wallet/core/tokens/TokensInteractorModule.kt
@@ -1,9 +1,5 @@
 package com.concordium.wallet.core.tokens
 
-import com.concordium.wallet.App
-import com.concordium.wallet.data.AccountRepository
-import com.concordium.wallet.data.ContractTokensRepository
-import com.concordium.wallet.data.PLTRepository
 import com.concordium.wallet.data.backend.price.tokenPriceModule
 import com.concordium.wallet.data.backend.repository.ProxyRepository
 import org.koin.dsl.module
@@ -17,15 +13,6 @@ val tokensInteractorModule = module {
     single {
         TokensInteractor(
             proxyRepository = ProxyRepository(),
-            contractTokensRepository = ContractTokensRepository(
-                App.appCore.session.walletStorage.database.contractTokenDao()
-            ),
-            pltRepository = PLTRepository(
-                App.appCore.session.walletStorage.database.protocolLevelTokenDao()
-            ),
-            accountRepository = AccountRepository(
-                App.appCore.session.walletStorage.database.accountDao()
-            ),
             tokenPriceRepository = get(),
             loadTokensBalancesUseCase = LoadTokensBalancesUseCase(),
             loadCIS2TokensUseCase = LoadCIS2TokensUseCase(),


### PR DESCRIPTION
## Purpose

Fix not showing tokens after switching wallets

## Changes

- Do not cache repos in long living TokensInteractor, as it breaks wallet switching – it keeps using instances for the previous wallet.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
